### PR TITLE
The ServicesInterface is now AppInterface (a breaking change) and refers to the App, not the Proactor.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridworks-proactor"
-version = "2.0.2"
+version = "3.0.0"
 description = "Gridworks Proactor"
 authors = ["Jessica Millar <jmillar@gridworks-consulting.com>"]
 license = "MIT"

--- a/src/gwproactor/__init__.py
+++ b/src/gwproactor/__init__.py
@@ -32,11 +32,11 @@ from gwproactor.proactor_implementation import Proactor
 from gwproactor.proactor_interface import (
     INVALID_IO_TASK_HANDLE,
     ActorInterface,
+    AppInterface,
     Communicator,
     CommunicatorInterface,
     MonitoredName,
     Runnable,
-    ServicesInterface,
 )
 from gwproactor.problems import Problems
 from gwproactor.sync_thread import (
@@ -74,7 +74,7 @@ __all__ = [
     "ProactorSettings",
     "Problems",
     "Runnable",
-    "ServicesInterface",
+    "AppInterface",
     "Subscription",
     "SyncAsyncInteractionThread",
     "SyncAsyncQueueWriter",

--- a/src/gwproactor/actors/actor.py
+++ b/src/gwproactor/actors/actor.py
@@ -14,9 +14,9 @@ from gwproactor.callbacks import ProactorCallbackInterface
 from gwproactor.codecs import CodecFactory
 from gwproactor.proactor_interface import (
     ActorInterface,
+    AppInterface,
     Communicator,
     MonitoredName,
-    ServicesInterface,
 )
 from gwproactor.sync_thread import SyncAsyncInteractionThread
 
@@ -24,13 +24,13 @@ from gwproactor.sync_thread import SyncAsyncInteractionThread
 class Actor(ActorInterface, Communicator, ABC):
     _node: ShNode
 
-    def __init__(self, name: str, services: ServicesInterface) -> None:
+    def __init__(self, name: str, services: AppInterface) -> None:
         self._node = services.hardware_layout.node(name)
         super().__init__(name, services)
 
     @classmethod
     def instantiate(
-        cls, name: str, services: "ServicesInterface", **constructor_args: Any
+        cls, name: str, services: "AppInterface", **constructor_args: Any
     ) -> "ActorInterface":
         return cls(
             name,
@@ -59,7 +59,7 @@ class SyncThreadActor(Actor, Generic[SyncThreadT]):
     def __init__(
         self,
         name: str,
-        services: ServicesInterface,
+        services: AppInterface,
         sync_thread: SyncAsyncInteractionThread,
     ) -> None:
         super().__init__(name, services)
@@ -100,7 +100,7 @@ class SyncThreadActor(Actor, Generic[SyncThreadT]):
 
 
 class PrimeActor(ProactorCallbackInterface, Actor):
-    def __init__(self, name: str, services: ServicesInterface) -> None:
+    def __init__(self, name: str, services: AppInterface) -> None:
         super().__init__(name, services)
         services.add_callbacks(self)
         services.add_communicator(self)

--- a/src/gwproactor/actors/rest.py
+++ b/src/gwproactor/actors/rest.py
@@ -15,7 +15,7 @@ from gwproto.data_classes.components.rest_poller_component import RESTPollerComp
 from gwproto.type_helpers import AioHttpClientTimeout, RESTPollerSettings, URLConfig
 from result import Ok, Result
 
-from gwproactor import Actor, Problems, ServicesInterface
+from gwproactor import Actor, AppInterface, Problems
 from gwproactor.proactor_interface import INVALID_IO_TASK_HANDLE, IOLoopInterface
 
 Converter = Callable[[ClientResponse], Awaitable[Optional[Message[Any]]]]
@@ -199,7 +199,7 @@ class RESTPollerActor(Actor):
     def __init__(
         self,
         name: str,
-        services: ServicesInterface,
+        services: AppInterface,
         *,
         convert: Converter = null_converter,
         forward: ThreadSafeForwarder = null_forwarder,

--- a/src/gwproactor/actors/web_event_listener.py
+++ b/src/gwproactor/actors/web_event_listener.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ValidationError
 from result import Result
 
 from gwproactor.actors.actor import Actor
-from gwproactor.proactor_interface import ServicesInterface
+from gwproactor.proactor_interface import AppInterface
 from gwproactor.problems import Problems
 
 EVENT_PATH: str = "/events"
@@ -30,7 +30,7 @@ class WebEventListener(Actor):
     def __init__(
         self,
         name: str,
-        services: ServicesInterface,
+        services: AppInterface,
         settings: Optional[WebEventListenerSettings] = None,
     ) -> None:
         super().__init__(name, services)

--- a/src/gwproactor/app.py
+++ b/src/gwproactor/app.py
@@ -29,9 +29,9 @@ from gwproactor.persister import PersisterInterface, StubPersister
 from gwproactor.proactor_implementation import Proactor
 from gwproactor.proactor_interface import (
     ActorInterface,
+    AppInterface,
     CommunicatorInterface,
     IOLoopInterface,
-    ServicesInterface,
     T,
 )
 from gwproactor.stats import ProactorStats
@@ -51,7 +51,7 @@ class ActorConfig:
     constructor_args: dict[str, Any] = field(default_factory=dict)
 
 
-class App(ServicesInterface):
+class App(AppInterface):
     _settings: AppSettings
     config: ProactorConfig
     links: dict[str, LinkSettings]

--- a/src/gwproactor/config/proactor_config.py
+++ b/src/gwproactor/config/proactor_config.py
@@ -10,7 +10,6 @@ from gwproactor.callbacks import ProactorCallbackFunctions
 from gwproactor.config.app_settings import AppSettings
 from gwproactor.logger import ProactorLogger
 from gwproactor.persister import PersisterInterface, StubPersister
-from gwproactor.stats import ProactorStats
 
 
 @dataclass
@@ -37,7 +36,6 @@ class ProactorConfig:
     callback_functions: ProactorCallbackFunctions
     logger: ProactorLogger
     event_persister: PersisterInterface
-    stats: ProactorStats
     layout: HardwareLayout
 
     def __init__(  # noqa: PLR0913

--- a/src/gwproactor/io_loop.py
+++ b/src/gwproactor/io_loop.py
@@ -11,10 +11,10 @@ from gwproactor.logger import ProactorLogger
 from gwproactor.message import KnownNames, PatInternalWatchdogMessage, ShutdownMessage
 from gwproactor.proactor_interface import (
     INVALID_IO_TASK_HANDLE,
+    AppInterface,
     Communicator,
     IOLoopInterface,
     MonitoredName,
-    ServicesInterface,
 )
 from gwproactor.problems import Problems
 from gwproactor.sync_thread import SyncAsyncInteractionThread
@@ -32,7 +32,7 @@ class IOLoop(Communicator, IOLoopInterface):
     _last_pat_time: float = 0.0
     _lg: ProactorLogger
 
-    def __init__(self, services: ServicesInterface) -> None:
+    def __init__(self, services: AppInterface) -> None:
         super().__init__(KnownNames.io_loop_manager.value, services)
         self._lg = services.logger
         self._lock = threading.RLock()

--- a/src/gwproactor/proactor_implementation.py
+++ b/src/gwproactor/proactor_implementation.py
@@ -59,11 +59,11 @@ from gwproactor.message import (
 )
 from gwproactor.persister import PersisterInterface
 from gwproactor.proactor_interface import (
+    AppInterface,
     CommunicatorInterface,
     IOLoopInterface,
     MonitoredName,
     Runnable,
-    ServicesInterface,
 )
 from gwproactor.problems import Problems
 from gwproactor.stats import ProactorStats
@@ -74,7 +74,7 @@ from gwproactor.web_manager import _WebManager
 T = TypeVar("T")
 
 
-class Proactor(ServicesInterface, Runnable):
+class Proactor(AppInterface, Runnable):
     AWAIT_PROCESSING_FUTURE_ATTRIBUTE: str = "_await_processing_future"
 
     _name: ProactorName

--- a/src/gwproactor/proactor_interface.py
+++ b/src/gwproactor/proactor_interface.py
@@ -55,9 +55,9 @@ class Communicator(CommunicatorInterface, ABC):
     """A partial implementation of CommunicatorInterface which supplies the trivial implementations"""
 
     _name: str
-    _services: "ServicesInterface"
+    _services: "AppInterface"
 
-    def __init__(self, name: str, services: "ServicesInterface") -> None:
+    def __init__(self, name: str, services: "AppInterface") -> None:
         self._name = name
         self._services = services
 
@@ -73,7 +73,7 @@ class Communicator(CommunicatorInterface, ABC):
         return []
 
     @property
-    def services(self) -> "ServicesInterface":
+    def services(self) -> "AppInterface":
         return self._services
 
 
@@ -119,7 +119,7 @@ class ActorInterface(CommunicatorInterface, Runnable, ABC):
     @classmethod
     @abstractmethod
     def instantiate(
-        cls, name: str, services: "ServicesInterface", **contstructor_kwargs: Any
+        cls, name: str, services: "AppInterface", **contstructor_kwargs: Any
     ) -> "ActorInterface":
         raise NotImplementedError
 
@@ -128,7 +128,7 @@ class ActorInterface(CommunicatorInterface, Runnable, ABC):
         cls,
         name: str,
         actor_class_name: str,
-        services: "ServicesInterface",
+        services: "AppInterface",
         actors_module: ModuleType,
         **constructor_kwargs: Any,
     ) -> "ActorInterface":
@@ -190,7 +190,7 @@ class IOLoopInterface(CommunicatorInterface, Runnable, ABC):
         """
 
 
-class ServicesInterface(ABC):
+class AppInterface(ABC):
     """Interface to system services (the proactor)"""
 
     @abstractmethod

--- a/src/gwproactor/proactor_interface.py
+++ b/src/gwproactor/proactor_interface.py
@@ -190,7 +190,7 @@ class IOLoopInterface(CommunicatorInterface, Runnable, ABC):
         """
 
 
-class ServicesInterface(CommunicatorInterface):
+class ServicesInterface(ABC):
     """Interface to system services (the proactor)"""
 
     @abstractmethod

--- a/src/gwproactor/watchdog.py
+++ b/src/gwproactor/watchdog.py
@@ -16,10 +16,10 @@ from gwproactor.message import (
     PatInternalWatchdog,
 )
 from gwproactor.proactor_interface import (
+    AppInterface,
     Communicator,
     MonitoredName,
     Runnable,
-    ServicesInterface,
 )
 
 
@@ -33,7 +33,7 @@ class WatchdogManager(Communicator, Runnable):
     _monitored_names: dict[str, _MonitoredName]
     _pat_external_watchdog_process_args: list[str]
 
-    def __init__(self, seconds_per_pat: float, services: ServicesInterface) -> None:
+    def __init__(self, seconds_per_pat: float, services: AppInterface) -> None:
         super().__init__(KnownNames.watchdog_manager.value, services)
         self.lg = services.logger
         self._seconds_per_pat = seconds_per_pat

--- a/src/gwproactor/web_manager.py
+++ b/src/gwproactor/web_manager.py
@@ -10,7 +10,7 @@ from gwproto import Message
 from gwproto.type_helpers import WebServerGt
 from result import Result
 
-from gwproactor.proactor_interface import Communicator, Runnable, ServicesInterface
+from gwproactor.proactor_interface import AppInterface, Communicator, Runnable
 
 
 class _RunWebServer:
@@ -51,7 +51,7 @@ class _WebManager(Communicator, Runnable):
     _configs: dict[str, WebServerGt]
     _routes: dict[str, list[RouteDef]]
 
-    def __init__(self, services: ServicesInterface) -> None:
+    def __init__(self, services: AppInterface) -> None:
         super().__init__("_WebManager", services)
         self._configs = {}
         self._routes = defaultdict(list)

--- a/src/gwproactor_test/dummies/pair/parent.py
+++ b/src/gwproactor_test/dummies/pair/parent.py
@@ -1,5 +1,6 @@
 """Scada implementation"""
 
+import typing
 from typing import Any
 
 from gwproto import HardwareLayout, Message
@@ -43,6 +44,10 @@ class DummyParentApp(App):
     @classmethod
     def prime_actor_type(cls) -> type[DummyParent]:
         return DummyParent
+
+    @property
+    def prime_actor(self) -> DummyParent:
+        return typing.cast(DummyParent, self._prime_actor)
 
     @classmethod
     def paths_name(cls) -> str:

--- a/src/gwproactor_test/dummies/tree/atn.py
+++ b/src/gwproactor_test/dummies/tree/atn.py
@@ -1,5 +1,6 @@
 """Scada implementation"""
 
+import typing
 from typing import Any, Optional
 
 from gwproto import HardwareLayout, Message
@@ -50,6 +51,10 @@ class DummyAtnApp(App):
     @classmethod
     def prime_actor_type(cls) -> type[DummyAtn]:
         return DummyAtn
+
+    @property
+    def prime_actor(self) -> DummyAtn:
+        return typing.cast(DummyAtn, self._prime_actor)
 
     @classmethod
     def paths_name(cls) -> Optional[str]:

--- a/src/gwproactor_test/dummies/tree/scada1.py
+++ b/src/gwproactor_test/dummies/tree/scada1.py
@@ -5,7 +5,7 @@ import rich
 from gwproto import HardwareLayout, Message
 from gwproto.messages import EventBase
 
-from gwproactor import App, AppSettings, ServicesInterface, actors
+from gwproactor import App, AppInterface, AppSettings, actors
 from gwproactor.actors.actor import PrimeActor
 from gwproactor.config import MQTTClient
 from gwproactor.config.links import CodecSettings, LinkSettings
@@ -33,7 +33,7 @@ from gwproactor_test.dummies.tree.messages import (
 class DummyScada1(PrimeActor):
     relays: RelayStates
 
-    def __init__(self, name: str, services: ServicesInterface) -> None:
+    def __init__(self, name: str, services: AppInterface) -> None:
         super().__init__(name, services)
         self.relays = RelayStates()
 

--- a/src/gwproactor_test/dummies/tree/scada1.py
+++ b/src/gwproactor_test/dummies/tree/scada1.py
@@ -244,6 +244,10 @@ class DummyScada1App(App):
     def prime_actor_type(cls) -> type[DummyScada1]:
         return DummyScada1
 
+    @property
+    def prime_actor(self) -> DummyScada1:
+        return typing.cast(DummyScada1, self._prime_actor)
+
     @classmethod
     def actors_module(cls) -> ModuleType:
         return actors

--- a/src/gwproactor_test/dummies/tree/scada2.py
+++ b/src/gwproactor_test/dummies/tree/scada2.py
@@ -155,6 +155,10 @@ class DummyScada2App(App):
     def prime_actor_type(cls) -> type[DummyScada2]:
         return DummyScada2
 
+    @property
+    def prime_actor(self) -> DummyScada2:
+        return typing.cast(DummyScada2, self._prime_actor)
+
     @classmethod
     def paths_name(cls) -> str:
         return DUMMY_SCADA2_NAME

--- a/src/gwproactor_test/dummies/tree/scada2.py
+++ b/src/gwproactor_test/dummies/tree/scada2.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import rich
 from gwproto import HardwareLayout, Message
 
-from gwproactor import App, AppSettings, ServicesInterface
+from gwproactor import App, AppInterface, AppSettings
 from gwproactor.actors.actor import PrimeActor
 from gwproactor.config import MQTTClient
 from gwproactor.config.links import CodecSettings, LinkSettings
@@ -30,7 +30,7 @@ class DummyScada2(PrimeActor):
 
     relays: dict[str, bool]
 
-    def __init__(self, name: str, services: ServicesInterface) -> None:
+    def __init__(self, name: str, services: AppInterface) -> None:
         super().__init__(name, services)
         self.relays = self.relays = defaultdict(bool)
 

--- a/src/gwproactor_test/live_test_helper.py
+++ b/src/gwproactor_test/live_test_helper.py
@@ -34,8 +34,8 @@ def get_option_value(
 
 
 class LiveTest:
-    parent_app: App
-    child_app: App
+    _parent_app: App
+    _child_app: App
     verbose: bool
     child_verbose: bool
     parent_verbose: bool
@@ -59,8 +59,8 @@ class LiveTest:
         parent_on_screen: Optional[bool] = None,
         request: typing.Any = None,
     ) -> None:
-        self.child_app = self._make_app(self.child_app_type(), child_app_settings)
-        self.parent_app = self._make_app(self.parent_app_type(), parent_app_settings)
+        self._child_app = self._make_app(self.child_app_type(), child_app_settings)
+        self._parent_app = self._make_app(self.parent_app_type(), parent_app_settings)
         self.verbose = get_option_value(
             parameter_value=verbose,
             option_name="--live-test-verbose",
@@ -96,9 +96,17 @@ class LiveTest:
     def child_app_type(cls) -> type[App]:
         return DummyChildApp
 
+    @property
+    def child_app(self) -> App:
+        return self._child_app
+
     @classmethod
     def parent_app_type(cls) -> type[App]:
         return DummyParentApp
+
+    @property
+    def parent_app(self) -> App:
+        return self._parent_app
 
     @classmethod
     def _make_app(cls, app_type: type[App], app_settings: Optional[AppSettings]) -> App:
@@ -179,13 +187,13 @@ class LiveTest:
     def remove_child(
         self,
     ) -> Self:
-        self.child_app.proactor = None
+        self.child_app.raw_proactor = None
         return self
 
     def remove_parent(
         self,
     ) -> Self:
-        self.parent_app.proactor = None
+        self.parent_app.raw_proactor = None
         return self
 
     @classmethod
@@ -252,9 +260,9 @@ class LiveTest:
 
     def get_proactors(self) -> list[InstrumentedProactor]:
         proactors = []
-        if self.child_app.proactor is not None:
+        if self.child_app.raw_proactor is not None:
             proactors.append(self.child)
-        if self.parent_app.proactor is not None:
+        if self.parent_app.raw_proactor is not None:
             proactors.append(self.parent)
         return proactors
 
@@ -308,11 +316,11 @@ class LiveTest:
 
     def summary_str(self) -> str:
         s = ""
-        if self.child_app.proactor is not None:
+        if self.child_app.raw_proactor is not None:
             s += "CHILD:\n" f"{self.child.summary_str()}\n"
         else:
             s += "CHILD: None\n"
-        if self.parent_app.proactor is not None:
+        if self.parent_app.raw_proactor is not None:
             s += "PARENT:\n" f"{self.parent.summary_str()}"
         else:
             s += "PARENT: None\n"

--- a/tests/test_proactor/test_comm/test_tree.py
+++ b/tests/test_proactor/test_comm/test_tree.py
@@ -101,7 +101,7 @@ async def test_tree_message_exchange(request: Any) -> None:
         assert stats2.num_received_by_type["gridworks.dummy.set.relay"] == 0
         relay_name = "scada2.relay1"
         h.child.logger.info("SETTING RELAY")
-        h.child_app.prime_actor.set_relay(relay_name, True)  # type: ignore[union-attr]
+        h.child_app.prime_actor.set_relay(relay_name, True)
 
         # wait for response to be received
         await await_for(
@@ -111,11 +111,11 @@ async def test_tree_message_exchange(request: Any) -> None:
             err_str_f=h.summary_str,
         )
         assert stats2.num_received_by_type["gridworks.dummy.set.relay"] == 1
-        assert h.child_app.prime_actor.relays.Relays == {  # type: ignore[union-attr]
+        assert h.child_app.prime_actor.relays.Relays == {
             relay_name: RelayInfoReported(Closed=True)
         }
-        assert h.child2_app.prime_actor.relays == {relay_name: True}  # type: ignore[union-attr]
-        assert h.child_app.prime_actor.relays.TotalChangeMismatches == 0  # type: ignore[union-attr]
+        assert h.child2_app.prime_actor.relays == {relay_name: True}
+        assert h.child_app.prime_actor.relays.TotalChangeMismatches == 0
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_tree_event_forward(request: Any) -> None:
             err_str_f=h.summary_str,
         )
         relay_name = "scada2.relay1"
-        h.child_app.prime_actor.set_relay(relay_name, True)  # type: ignore[union-attr]
+        h.child_app.prime_actor.set_relay(relay_name, True)
 
         statsAtnTo1 = h.parent.stats.link(h.parent.downstream_client)
 


### PR DESCRIPTION
This allows Actors, which receive the services object, to test type of the services object and then make use of type refinement provided by the app. For example, a ScadaActor can test/cast the services object to a ScadaApp, and then access the Scada as `services.prime_actor`. The rename of the ServicesInterface to AppInterface is a breaking change, so major version is increased. 