### PR TITLE
Moved default env file location config directory (breaking change)

### DIFF
--- a/src/gwproactor/config/__init__.py
+++ b/src/gwproactor/config/__init__.py
@@ -23,14 +23,11 @@ from gwproactor.config.paths import (
 )
 from gwproactor.config.proactor_settings import ProactorSettings
 
-DEFAULT_ENV_FILE = ".env"
-
 __all__ = [
     "DEFAULT_BASE_DIR",
     "DEFAULT_BASE_NAME",
     "DEFAULT_BYTES_PER_LOG_FILE",
     # paths
-    "DEFAULT_ENV_FILE",
     "DEFAULT_FRACTIONAL_SECOND_FORMAT",
     "DEFAULT_LAYOUT_FILE",
     # logging

--- a/src/gwproactor/config/paths.py
+++ b/src/gwproactor/config/paths.py
@@ -183,3 +183,12 @@ class Paths(BaseModel):
         )
         fields.update(**kwargs)
         return Paths(**fields)
+
+    @classmethod
+    def default_env_path(
+        cls,
+        name: str,
+        paths: Optional["Paths"] = None,
+    ) -> Path:
+        paths = Paths(name=name) if paths is None else paths.duplicate(name=name)
+        return Path(paths.config_dir).absolute() / ".env"

--- a/src/gwproactor_test/certs.py
+++ b/src/gwproactor_test/certs.py
@@ -95,10 +95,10 @@ def _copy_keys(test_cert_dir: Path, dst_paths: TLSPaths) -> None:
             f"One or more TLS test keys at {test_cert_dir} does not exist. Recreating."
         )
         print(
-            f"  Cert path        exists:{src_paths.cert_path.exists()!s:5s}  {src_paths.cert_path}"
+            f"  Cert path        exists: {src_paths.cert_path.exists()!s:5s}  {src_paths.cert_path}"
         )
         print(
-            f"  Private key path exists:{src_paths.private_key_path.exists()!s:5s}  {src_paths.private_key_path}"
+            f"  Private key path exists: {src_paths.private_key_path.exists()!s:5s}  {src_paths.private_key_path}"
         )
         gwcert_command = [
             "gwcert",

--- a/src/gwproactor_test/cli.py
+++ b/src/gwproactor_test/cli.py
@@ -1,11 +1,14 @@
-import dotenv
 import typer
 from trogon import Trogon
 from typer.main import get_group
 
+from gwproactor.config import Paths
 from gwproactor_test.certs import generate_dummy_certs
 from gwproactor_test.dummies.tree import admin_cli, atn1_cli, scada1_cli, scada2_cli
-from gwproactor_test.dummies.tree.admin_settings import DummyAdminSettings
+from gwproactor_test.dummies.tree.admin_settings import (
+    AdminLinkSettings,
+    DummyAdminSettings,
+)
 from gwproactor_test.dummies.tree.atn import DummyAtnApp
 from gwproactor_test.dummies.tree.scada1 import DummyScada1App
 from gwproactor_test.dummies.tree.scada2 import DummyScada2App
@@ -24,16 +27,20 @@ app.add_typer(admin_cli.app, name="admin", help="Use dummy admin")
 
 
 @app.command()
-def gen_dummy_certs(
-    dry_run: bool = False, env_file: str = ".env", only: str = ""
-) -> None:
+def gen_dummy_certs(dry_run: bool = False, only: str = "") -> None:
     """Generate certs for dummy proactors."""
-    env_file = dotenv.find_dotenv(env_file, usecwd=True)
     for app_name, settings in [
-        ("atn", DummyAtnApp(env_file=env_file).settings),
-        ("scada1", DummyScada1App(env_file=env_file).settings),
-        ("scada2", DummyScada2App(env_file=env_file).settings),
-        ("admin", DummyAdminSettings(_env_file=env_file)),  # noqa
+        ("atn", DummyAtnApp(env_file=DummyAtnApp.default_env_path()).settings),
+        ("scada1", DummyScada1App(env_file=DummyScada1App.default_env_path()).settings),
+        ("scada2", DummyScada2App(env_file=DummyScada2App.default_env_path()).settings),
+        (
+            "admin",
+            DummyAdminSettings(
+                _env_file=Paths.default_env_path(  # noqa
+                    name=AdminLinkSettings.DUMMY_ADMIN_PATHS_NAME
+                )
+            ),
+        ),  # noqa
     ]:
         if only and only != app_name:
             continue

--- a/src/gwproactor_test/dummies/tree/admin_cli.py
+++ b/src/gwproactor_test/dummies/tree/admin_cli.py
@@ -1,12 +1,13 @@
 from enum import StrEnum
 from pathlib import Path
 
-import dotenv
 import rich
 import typer
 
+from gwproactor.config import Paths
 from gwproactor_test.dummies.tree.admin import MQTTAdmin
 from gwproactor_test.dummies.tree.admin_settings import (
+    AdminLinkSettings,
     DummyAdminSettings,
 )
 
@@ -81,13 +82,18 @@ def run(
 @app.command()
 def config(
     target: str = DummyAdminSettings.DEFAULT_TARGET,
-    env_file: str = ".env",
+    env_file: str = "",
 ) -> None:
-    settings = DummyAdminSettings(_env_file=env_file, target_gnode=target)  # noqa
-    dotenv_file = dotenv.find_dotenv(str(env_file))
+    env_path = Path(
+        env_file
+        if env_file
+        else Paths.default_env_path(name=AdminLinkSettings.DUMMY_ADMIN_PATHS_NAME)
+    ).absolute()
     rich.print(
-        f"Env file: <{dotenv_file}>  exists:{env_file and Path(dotenv_file).exists()}"
+        f"Env file: <{env_path!s}>  exists: {bool(env_file and Path(env_path).exists())}"
     )
+    settings = DummyAdminSettings(_env_file=str(env_path), target_gnode=target)  # noqa
+
     rich.print(settings)
     missing_tls_paths_ = settings.check_tls_paths_present(raise_error=False)
     if missing_tls_paths_:

--- a/src/gwproactor_test/dummies/tree/atn1_cli.py
+++ b/src/gwproactor_test/dummies/tree/atn1_cli.py
@@ -12,7 +12,7 @@ app = typer.Typer(
 
 @app.command()
 def run(
-    env_file: str = ".env",
+    env_file: str = "",
     dry_run: bool = False,
     verbose: bool = False,
     message_summary: bool = False,
@@ -27,7 +27,7 @@ def run(
 
 @app.command()
 def config(
-    env_file: str = ".env",
+    env_file: str = "",
 ) -> None:
     DummyAtnApp.print_settings(env_file=env_file)
 

--- a/src/gwproactor_test/dummies/tree/scada1_cli.py
+++ b/src/gwproactor_test/dummies/tree/scada1_cli.py
@@ -12,7 +12,7 @@ app = typer.Typer(
 
 @app.command()
 def run(
-    env_file: str = ".env",
+    env_file: str = "",
     dry_run: bool = False,
     verbose: bool = False,
     message_summary: bool = False,
@@ -33,7 +33,7 @@ def run(
 
 @app.command()
 def config(
-    env_file: str = ".env",
+    env_file: str = "",
 ) -> None:
     DummyScada1App.print_settings(env_file=env_file)
 

--- a/src/gwproactor_test/dummies/tree/scada2_cli.py
+++ b/src/gwproactor_test/dummies/tree/scada2_cli.py
@@ -12,7 +12,7 @@ app = typer.Typer(
 
 @app.command()
 def run(
-    env_file: str = ".env",
+    env_file: str = "",
     dry_run: bool = False,
     verbose: bool = False,
     message_summary: bool = False,
@@ -27,7 +27,7 @@ def run(
 
 @app.command()
 def config(
-    env_file: str = ".env",
+    env_file: str = "",
 ) -> None:
     DummyScada2App.print_settings(env_file=env_file)
 


### PR DESCRIPTION
The default location for config .env files will now be the app's config directory, $HOME/.config/gridworks/APP-NAME. This removes necessity for apps installed as packages to choose and use a command location for .env files, which is easy to forget when running command line tools. 