### PR TITLE
Events no longer persisted while link is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [tests]: https://github.com/thegridelectric/gridworks-proactor/actions?workflow=Tests
 
-[codecov]: https://app.codecov.io/gh/thegridelectric/gridworks-proactor
+[codecov]: https://app.codecov.io/gh/SmoothStoneComputing/gridworks-proactor
 
 [pre-commit]: https://github.com/pre-commit/pre-commit
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Read the documentation at https://gridworks-proactor.readthedocs.io/](https://img.shields.io/readthedocs/gridworks-proactor/latest.svg?label=Read%20the%20Docs)][read the docs]
 [![Tests](https://github.com/thegridelectric/gridworks-proactor/workflows/Tests/badge.svg)][tests]
-[![Codecov](https://codecov.io/gh/thegridelectric/gridworks-proactor/branch/main/graph/badge.svg)][codecov]
+[![Codecov](https://app.codecov.io/gh/SmoothStoneComputing/gridworks-proactor/branch/main/graph/badge.svg)][codecov]
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]

--- a/src/gwproactor/config/proactor_settings.py
+++ b/src/gwproactor/config/proactor_settings.py
@@ -3,12 +3,15 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 MQTT_LINK_POLL_SECONDS = 60.0
 ACK_TIMEOUT_SECONDS = 5.0
 NUM_INITIAL_EVENT_REUPLOADS: int = 5
+NUM_INFLIGHT_EVENTS: int = 50
 
 
 class ProactorSettings(BaseSettings):
     mqtt_link_poll_seconds: float = MQTT_LINK_POLL_SECONDS
     ack_timeout_seconds: float = ACK_TIMEOUT_SECONDS
     num_initial_event_reuploads: int = NUM_INITIAL_EVENT_REUPLOADS
+    num_inflight_events: int = NUM_INFLIGHT_EVENTS
+
     model_config = SettingsConfigDict(
         env_prefix="PROACTOR_",
         env_nested_delimiter="__",

--- a/src/gwproactor/links/link_manager.py
+++ b/src/gwproactor/links/link_manager.py
@@ -312,16 +312,14 @@ class LinkManager:
             path_dbg |= 0x00000008
             if len(self._in_flight_events) >= self._settings.num_inflight_events:
                 path_dbg |= 0x00000010
-                oldest_event_id = next(iter(self._in_flight_events))
-                oldest_event = self._in_flight_events.pop(oldest_event_id)
                 result = self._event_persister.persist(
-                    oldest_event.MessageId,
-                    oldest_event.model_dump_json().encode(PERSISTER_ENCODING),
+                    event.MessageId,
+                    event.model_dump_json().encode(PERSISTER_ENCODING),
                 )
             else:
                 path_dbg |= 0x00000020
+                self._in_flight_events[event.MessageId] = event
                 result = Ok()
-            self._in_flight_events[event.MessageId] = event
             self.publish_upstream(event, AckRequired=True)
         else:
             result = self._event_persister.persist(

--- a/src/gwproactor/links/link_manager.py
+++ b/src/gwproactor/links/link_manager.py
@@ -289,7 +289,7 @@ class LinkManager:
         self._logger.path(
             "++generate_event %s  f: %d  (p: %d)",
             event.TypeName,
-            0,  # len(self._in_flight_events),
+            len(self._in_flight_events),
             self._event_persister.num_pending,
         )
         if not event.Src:

--- a/src/gwproactor/links/mqtt.py
+++ b/src/gwproactor/links/mqtt.py
@@ -111,7 +111,9 @@ class MQTTClientWrapper:
         self._pending_subscriptions = set()
         self._pending_subacks = {}
         self._thread = threading.Thread(
-            target=self._client_thread, name=f"MQTT-client-thread-{self._client_name}"
+            target=self._client_thread,
+            name=f"MQTT-client-thread-{self._client_name}",
+            daemon=True,
         )
         self._stop_requested = False
 

--- a/src/gwproactor/persister/interface.py
+++ b/src/gwproactor/persister/interface.py
@@ -43,3 +43,18 @@ class PersisterInterface(abc.ABC):
     @abstractmethod
     def reindex(self) -> Result[Optional[bool], Problems]:
         """Re-created pending index from persisted storage"""
+
+    @property
+    @abstractmethod
+    def num_persists(self) -> int:
+        """Total number of calls to persist() since construction."""
+
+    @property
+    @abstractmethod
+    def num_retrieves(self) -> int:
+        """Total number of calls to retrieve() since construction."""
+
+    @property
+    @abstractmethod
+    def num_clears(self) -> int:
+        """Total number of calls to clear() since construction."""

--- a/src/gwproactor/persister/simple_directory_writer.py
+++ b/src/gwproactor/persister/simple_directory_writer.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ERA001
+
 import datetime
 from pathlib import Path
 
@@ -22,6 +24,15 @@ class SimpleDirectoryWriter(StubPersister):
         return f"{dt.isoformat()}.uid[{uid}].json"
 
     def persist(self, uid: str, content: bytes) -> Result[bool, Problems]:
+        self._num_persists += 1
+        # from gwproto.messages import AnyEvent
+        # event = AnyEvent.model_validate_json(content.decode())
+        # print(
+        #     f"{self._num_persists:3d}  "
+        #     f"{event.TypeName:45s}  "
+        #     f"{event.Src:35s}  "
+        #     f"{event.MessageId[:8]}"
+        # )
         problems = Problems()
         try:
             if not self._base_dir.exists():

--- a/src/gwproactor/persister/stub.py
+++ b/src/gwproactor/persister/stub.py
@@ -7,10 +7,16 @@ from gwproactor.problems import Problems
 
 
 class StubPersister(PersisterInterface):
+    _num_persists: int = 0
+    _num_retrieves: int = 0
+    _num_clears: int = 0
+
     def persist(self, uid: str, content: bytes) -> Result[bool, Problems]:  # noqa: ARG002
+        self._num_persists += 1
         return Ok()
 
     def clear(self, uid: str) -> Result[bool, Problems]:  # noqa: ARG002
+        self._num_clears += 1
         return Ok()
 
     def pending_ids(self) -> list[str]:
@@ -31,4 +37,17 @@ class StubPersister(PersisterInterface):
         return Ok(None)
 
     def reindex(self) -> Result[Optional[bool], Problems]:
+        self._num_retrieves += 1
         return Ok()
+
+    @property
+    def num_persists(self) -> int:
+        return self._num_persists
+
+    @property
+    def num_retrieves(self) -> int:
+        return self._num_retrieves
+
+    @property
+    def num_clears(self) -> int:
+        return self._num_clears

--- a/src/gwproactor/proactor_implementation.py
+++ b/src/gwproactor/proactor_implementation.py
@@ -803,6 +803,7 @@ class Proactor(AppInterface, Runnable):
     def _process_shutdown_message(self, message: Message[Shutdown]) -> None:
         self._stop_requested = True
         self.generate_event(ShutdownEvent(Reason=message.Payload.Reason))
+        self._links.flush_in_flight_events()
         self._logger.lifecycle(
             f"Shutting down due to ShutdownMessage, [{message.Payload.Reason}]"
         )

--- a/src/gwproactor/problems.py
+++ b/src/gwproactor/problems.py
@@ -77,3 +77,6 @@ class Problems(ValueError):
             Summary=summary,
             Details=str(self),
         )
+
+    def __len__(self) -> int:
+        return len(self.errors) + len(self.warnings)

--- a/src/gwproactor_test/dummies/pair/parent.py
+++ b/src/gwproactor_test/dummies/pair/parent.py
@@ -13,7 +13,7 @@ from gwproactor.config import MQTTClient
 from gwproactor.config.links import LinkSettings
 from gwproactor.config.proactor_config import ProactorName
 from gwproactor.message import DBGPayload, MQTTReceiptPayload
-from gwproactor.persister import PersisterInterface, SimpleDirectoryWriter
+from gwproactor.persister import PersisterInterface, SQLitePersister
 from gwproactor_test.dummies import DUMMY_CHILD_NAME, DUMMY_PARENT_NAME
 
 
@@ -96,4 +96,4 @@ class DummyParentApp(App):
 
     @classmethod
     def _make_persister(cls, settings: AppSettings) -> PersisterInterface:
-        return SimpleDirectoryWriter(settings.paths.event_dir)
+        return SQLitePersister(settings.paths.event_dir)

--- a/src/gwproactor_test/dummies/tree/atn.py
+++ b/src/gwproactor_test/dummies/tree/atn.py
@@ -30,6 +30,7 @@ class DummyAtn(PrimeActor):
         match decoded.Payload:
             case EventBase():
                 path_dbg |= 0x00000001
+                self.services.generate_event(decoded.Payload)
             case _:
                 path_dbg |= 0x00000002
         self.services.logger.path(

--- a/src/gwproactor_test/dummies/tree/atn.py
+++ b/src/gwproactor_test/dummies/tree/atn.py
@@ -12,7 +12,7 @@ from gwproactor.config import MQTTClient
 from gwproactor.config.links import LinkSettings
 from gwproactor.config.proactor_config import ProactorName
 from gwproactor.message import MQTTReceiptPayload
-from gwproactor.persister import PersisterInterface, SimpleDirectoryWriter
+from gwproactor.persister import PersisterInterface, SQLitePersister
 from gwproactor_test.dummies import DUMMY_SCADA1_NAME
 from gwproactor_test.dummies.names import DUMMY_ATN_NAME
 
@@ -84,4 +84,4 @@ class DummyAtnApp(App):
 
     @classmethod
     def _make_persister(cls, settings: AppSettings) -> PersisterInterface:
-        return SimpleDirectoryWriter(settings.paths.event_dir)
+        return SQLitePersister(settings.paths.event_dir)

--- a/src/gwproactor_test/instrumented_proactor.py
+++ b/src/gwproactor_test/instrumented_proactor.py
@@ -309,7 +309,12 @@ class InstrumentedProactor(Proactor):
 
     def summary_str(self) -> str:
         s = str(self.stats)
-        s += f"\nIn-flight events: {len(self.links.in_flight_events)}\n"
+        s += "\nEvents:\n"
+        s += f"  pending: {self.links.num_pending}\n"
+        s += f"  in-flight: {self.links.num_in_flight}\n"
+        s += f"  persisted: {self.event_persister.num_persists}\n"
+        s += f"  retrieved: {self.event_persister.num_retrieves}\n"
+        s += f"  cleared: {self.event_persister.num_clears}\n"
         s += "Link states:\n"
         for link_name in self.stats.links:
             link_state = self._links.link_state(link_name)

--- a/src/gwproactor_test/instrumented_proactor.py
+++ b/src/gwproactor_test/instrumented_proactor.py
@@ -478,9 +478,14 @@ class InstrumentedProactor(Proactor):
             assert_count(0, p.num_retrieves, tag + " num_retrieves", err_str)
             assert_count(0, p.num_clears, tag + " num_clears", err_str)
         if all_clear:
-            assert_count(0, self.links.num_pending, tag + " num_pending", err_str)
-            assert_count(num_persists, p.num_persists, tag + " num_persists", err_str)
-            assert_count(num_persists, p.num_retrieves, tag + " num_retrieves", err_str)
-            assert_count(num_persists, p.num_clears, tag + " num_clears", err_str)
+            if num_pending != 0:
+                raise ValueError(
+                    f"ERROR. all_clear is True but num_pending ({num_pending}) != 0"
+                )
+            if num_retrieves is None:
+                num_retrieves = num_persists
+            if num_clears is None:
+                num_clears = num_persists
+        assert_count(num_persists, p.num_persists, tag + " num_persists", err_str)
         assert_count(num_retrieves, p.num_retrieves, tag + " num_retrieves", err_str)
         assert_count(num_clears, p.num_clears, tag + " num_clears", err_str)

--- a/src/gwproactor_test/instrumented_proactor.py
+++ b/src/gwproactor_test/instrumented_proactor.py
@@ -1,6 +1,7 @@
 # ruff: noqa: ERA001
 
 import dataclasses
+import logging
 import typing
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -363,12 +364,13 @@ class InstrumentedProactor(Proactor):
     def summarize(self) -> None:
         self._logger.info(self.summary_str())
 
-    def delimit(self, text: str = "") -> None:
-        if self._logger.general_enabled:
-            self._logger.info(
+    def delimit(self, text: str = "", log_level: int = logging.INFO) -> None:
+        if self._logger.isEnabledFor(log_level):
+            self._logger.log(
+                log_level,
                 f"\n\n{self.DELIMIT_STR}\n"
                 f"{self.DELIMIT_CHAR}  {text}\n"
-                f"{self.DELIMIT_STR}\n"
+                f"{self.DELIMIT_STR}\n",
             )
 
     def force_ping(self, client_name: str) -> None:
@@ -455,7 +457,7 @@ class InstrumentedProactor(Proactor):
             persist_check = self.event_persister.num_persists >= num_persists
         return pending_check and self.links.num_in_flight == 0 and persist_check
 
-    def assert_events_at_rest(
+    def assert_event_counts(
         self,
         *,
         num_pending: Optional[int | tuple[int | None, int | None]] = 0,

--- a/src/gwproactor_test/instrumented_proactor.py
+++ b/src/gwproactor_test/instrumented_proactor.py
@@ -321,6 +321,7 @@ class InstrumentedProactor(Proactor):
         for link_name in self.stats.links:
             s += f"  {link_name:10s}  {self._links.num_acks(link_name):3d}\n"
         s += self._links.get_reuploads_str() + "\n"
+        s += f"Paused acks: {len(self.needs_ack)}\n"
         s += "Paused Subacks:"
         for link_name in self.stats.links:
             s += (

--- a/src/gwproactor_test/instrumented_proactor.py
+++ b/src/gwproactor_test/instrumented_proactor.py
@@ -94,6 +94,14 @@ class RecorderLinks(LinkManager):
             raise RuntimeError(f"Link {name} not found.")
         return link
 
+    @property
+    def in_flight_events(self) -> dict[str, EventBase]:
+        return self._in_flight_events
+
+    @property
+    def num_in_flight(self) -> int:
+        return len(self._in_flight_events)
+
     def publish_message(
         self,
         link_name: str,
@@ -194,7 +202,7 @@ class InstrumentedProactor(Proactor):
     def force_mqtt_disconnect(self, client_name: str) -> None:
         mqtt_client = self.mqtt_client_wrapper(client_name).mqtt_client
         # noinspection PyProtectedMember
-        mqtt_client._loop_rc_handle(MQTT_ERR_CONN_LOST)  # noqa: SLF001
+        mqtt_client._loop_rc_handle(MQTT_ERR_CONN_LOST)  # noqa
 
     def _process_mqtt_message(
         self, mqtt_receipt_message: Message[MQTTReceiptPayload]
@@ -301,7 +309,8 @@ class InstrumentedProactor(Proactor):
 
     def summary_str(self) -> str:
         s = str(self.stats)
-        s += "\nLink states:\n"
+        s += f"\nIn-flight events: {len(self.links.in_flight_events)}\n"
+        s += "Link states:\n"
         for link_name in self.stats.links:
             link_state = self._links.link_state(link_name)
             if link_state is None:

--- a/src/gwproactor_test/live_test_helper.py
+++ b/src/gwproactor_test/live_test_helper.py
@@ -308,8 +308,8 @@ class LiveTest:
         return (
             f"CommTestHelper caught error {exc}.\n"
             "Working log dirs:"
-            f"\n\t[{self.child_app.config.settings.paths.log_dir}]"
-            f"\n\t[{self.parent_app.config.settings.paths.log_dir}]"
+            f"\n\t{self.child_app.config.settings.paths.log_dir}"
+            f"\n\t{self.parent_app.config.settings.paths.log_dir}"
         )
 
     async def __aexit__(

--- a/src/gwproactor_test/live_test_helper.py
+++ b/src/gwproactor_test/live_test_helper.py
@@ -353,14 +353,14 @@ class LiveTest:
     def assert_child_events_at_rest(
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
-        self.child.assert_events_at_rest(*args, **kwargs)
+        self.child.assert_event_counts(*args, **kwargs)
 
     def assert_child1_events_at_rest(
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
-        self.child.assert_events_at_rest(*args, **kwargs)
+        self.child.assert_event_counts(*args, **kwargs)
 
     def assert_parent_events_at_rest(
         self, *args: typing.Any, **kwargs: typing.Any
     ) -> None:
-        self.child.assert_events_at_rest(*args, **kwargs)
+        self.child.assert_event_counts(*args, **kwargs)

--- a/src/gwproactor_test/live_test_helper.py
+++ b/src/gwproactor_test/live_test_helper.py
@@ -349,3 +349,18 @@ class LiveTest:
         else:
             s += "PARENT: None\n"
         return s
+
+    def assert_child_events_at_rest(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
+        self.child.assert_events_at_rest(*args, **kwargs)
+
+    def assert_child1_events_at_rest(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
+        self.child.assert_events_at_rest(*args, **kwargs)
+
+    def assert_parent_events_at_rest(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
+        self.child.assert_events_at_rest(*args, **kwargs)

--- a/src/gwproactor_test/wait.py
+++ b/src/gwproactor_test/wait.py
@@ -53,9 +53,8 @@ async def await_for(  # noqa: C901, PLR0912, PLR0913
     now = start = time.time()
     until = now + timeout
     err_format = (
-        "ERROR. [{tag}] await_for() timed out after {seconds} seconds\n"
-        "  [{tag}]\n"
-        "  From {file}:{line}\n"
+        "ERROR from {file}:{line}  [{tag}]\n"
+        "  await_for() timed out after {seconds} seconds\n"
         "  wait function: {f}"
         "{err_str}"
     )

--- a/tests/test_misc/test_responsive_sleep.py
+++ b/tests/test_misc/test_responsive_sleep.py
@@ -32,22 +32,33 @@ class StopMe:
 MAX_DELAY = 0.01
 
 
-def test_responsive_sleep() -> None:
+# "pre-compile" code before tests to cut down on failures caused by
+# compilation delay
+def check_responsive_sleep(*, precompile_only: bool = False) -> None:
     sw = StopWatch()
     seconds = 0.1
     with sw:
         responsive_sleep(StopMe(), seconds, running_field_name="running")
-    assert seconds <= sw.elapsed < seconds + MAX_DELAY
+    if not precompile_only:
+        assert seconds <= sw.elapsed < seconds + MAX_DELAY
     seconds = 0.01
     with sw:
         responsive_sleep(StopMe(), seconds, running_field_name="running")
-    assert seconds <= sw.elapsed < seconds + MAX_DELAY
+    if not precompile_only:
+        assert seconds <= sw.elapsed < seconds + MAX_DELAY
     with sw:
         responsive_sleep(StopMe(running=False), seconds, running_field_name="running")
-    assert 0 <= sw.elapsed < MAX_DELAY
+    if not precompile_only:
+        assert 0 <= sw.elapsed < MAX_DELAY
     step_duration = 0.1
     stop_me = StopMe(step_duration=step_duration)
     stop_me.start()
     with sw:
         stop_me.stop()
-    assert 0 <= sw.elapsed < step_duration + MAX_DELAY
+    if not precompile_only:
+        assert 0 <= sw.elapsed < step_duration + MAX_DELAY
+
+
+def test_responsive_sleep() -> None:
+    check_responsive_sleep(precompile_only=True)
+    check_responsive_sleep()

--- a/tests/test_proactor/test_comm/test_basic_comm.py
+++ b/tests/test_proactor/test_comm/test_basic_comm.py
@@ -15,12 +15,12 @@ from gwproactor_test.wait import await_for
 async def test_no_parent(request: Any) -> None:
     async with LiveTest(add_child=True, request=request) as h:
         child = h.child
-        stats = child.stats.link(child.upstream_client)
-        comm_event_counts = stats.comm_event_counts
+        link_stats = child.stats.link(child.upstream_client)
+        comm_event_counts = link_stats.comm_event_counts
         link = child.links.link(child.upstream_client)
 
         # unstarted child
-        assert stats.num_received == 0
+        assert link_stats.num_received == 0
         assert link.state == StateName.not_started
         child.logger.info(child.settings.model_dump_json(indent=2))
 
@@ -38,8 +38,11 @@ async def test_no_parent(request: Any) -> None:
         assert comm_event_counts["gridworks.event.comm.mqtt.connect"] == 1
         assert comm_event_counts["gridworks.event.comm.mqtt.fully.subscribed"] == 1
         assert comm_event_counts["gridworks.event.comm.mqtt.disconnect"] == 0
-        assert len(stats.comm_events) == 2
-        for comm_event in stats.comm_events:
+        assert child.links.num_pending == 3  # 2 comm events + 1 startup event
+        assert child.event_persister.num_persists == 3
+        assert child.links.num_in_flight == 0
+        assert len(link_stats.comm_events) == 2
+        for comm_event in link_stats.comm_events:
             assert comm_event.MessageId in child.event_persister
 
         # Tell client we lost comm.
@@ -47,10 +50,7 @@ async def test_no_parent(request: Any) -> None:
 
         # Wait for reconnect
         await await_for(
-            lambda: stats.comm_event_counts[
-                "gridworks.event.comm.mqtt.fully.subscribed"
-            ]
-            > 1,
+            lambda: comm_event_counts["gridworks.event.comm.mqtt.fully.subscribed"] > 1,
             3,
             "ERROR waiting link to resubscribe after comm loss",
             err_str_f=child.summary_str,
@@ -62,8 +62,11 @@ async def test_no_parent(request: Any) -> None:
         assert comm_event_counts["gridworks.event.comm.mqtt.connect"] == 2
         assert comm_event_counts["gridworks.event.comm.mqtt.fully.subscribed"] == 2
         assert comm_event_counts["gridworks.event.comm.mqtt.disconnect"] == 1
-        assert len(stats.comm_events) == 5
-        for comm_event in stats.comm_events:
+        assert child.links.num_pending == 6  # 5 comm events + 1 startup event
+        assert child.event_persister.num_persists == 6
+        assert child.links.num_in_flight == 0
+        assert len(link_stats.comm_events) == 5
+        for comm_event in link_stats.comm_events:
             assert comm_event.MessageId in child.event_persister
 
 
@@ -96,6 +99,9 @@ async def test_basic_comm_child_first(request: Any) -> None:
         )
         assert child_comm_event_counts["gridworks.event.comm.mqtt.disconnect"] == 0
         assert child_comm_event_counts["gridworks.event.comm.peer.active"] == 0
+        assert child.links.num_pending == 3  # 2 comm events + 1 startup event
+        assert child.event_persister.num_persists == 3
+        assert child.links.num_in_flight == 0
         assert len(child_stats.comm_events) == 2
         for comm_event in child_stats.comm_events:
             assert comm_event.MessageId in child.event_persister
@@ -120,6 +126,7 @@ async def test_basic_comm_child_first(request: Any) -> None:
         assert child_comm_event_counts["gridworks.event.comm.mqtt.disconnect"] == 0
         assert child_comm_event_counts["gridworks.event.comm.peer.active"] == 1
         assert len(child_stats.comm_events) == 3
+        assert 0 <= child.links.num_in_flight <= 4
 
         # wait for all events to be acked
         await await_for(
@@ -128,8 +135,12 @@ async def test_basic_comm_child_first(request: Any) -> None:
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        assert child.links.num_in_flight == 0
+        assert child.event_persister.num_persists == 3
+        assert child.event_persister.num_retrieves == 3
+        assert child.event_persister.num_clears == 3
 
-        # Tell client we lost comm.
+        # Tell client we lost comm
         child.force_mqtt_disconnect("parent")
 
         # Wait for reconnect
@@ -151,6 +162,7 @@ async def test_basic_comm_child_first(request: Any) -> None:
         assert child_comm_event_counts["gridworks.event.comm.mqtt.disconnect"] == 1
         assert child_comm_event_counts["gridworks.event.comm.peer.active"] == 2
         assert len(child_stats.comm_events) == 7
+        assert 0 <= child.links.num_in_flight <= 4
 
         # wait for all events to be acked
         await await_for(
@@ -159,6 +171,11 @@ async def test_basic_comm_child_first(request: Any) -> None:
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        assert child.links.num_in_flight == 0
+        # peer active event should never be persisted
+        assert child.event_persister.num_persists == 6
+        assert child.event_persister.num_retrieves == 6
+        assert child.event_persister.num_clears == 6
 
 
 @pytest.mark.asyncio
@@ -217,7 +234,6 @@ async def test_basic_comm_parent_first(request: Any, suppress_tls: bool) -> None
         assert child_link.active()
         assert StateName(child_link.state) == StateName.active
         assert child_comm_event_counts["gridworks.event.comm.mqtt.connect"] == 1
-
         assert (
             child_comm_event_counts["gridworks.event.comm.mqtt.fully.subscribed"] == 1
         )
@@ -227,11 +243,16 @@ async def test_basic_comm_parent_first(request: Any, suppress_tls: bool) -> None
 
         # wait for all events to be acked
         await await_for(
-            lambda: child.event_persister.num_pending == 0,
+            lambda: child.event_persister.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        # peer active event should never be persisted
+        assert child.event_persister.num_persists == 3
+        assert child.event_persister.num_retrieves == 3
+        assert child.event_persister.num_clears == 3
 
 
 @pytest.mark.asyncio
@@ -271,11 +292,16 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
 
         # wait for all events to be acked
         await await_for(
-            lambda: child.event_persister.num_pending == 0,
+            lambda: child.event_persister.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        # peer-active event should never be persisted
+        assert child.event_persister.num_persists == 3
+        assert child.event_persister.num_retrieves == 3
+        assert child.event_persister.num_clears == 3
 
         # Tell *child* client we lost comm.
         child.force_mqtt_disconnect(child.upstream_client)
@@ -302,16 +328,17 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
 
         # wait for all events to be acked
         await await_for(
-            lambda: child.event_persister.num_pending == 0,
+            lambda: child.event_persister.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        assert child.event_persister.num_persists == 6
+        assert child.event_persister.num_retrieves == 6
+        assert child.event_persister.num_clears == 6
 
-        # Tell *parent* client we lost comm.
-        parent.force_mqtt_disconnect(parent.downstream_client)
-        # wait for child to get ping from parent when parent reconnects to mqtt
-        # noinspection PyTypeChecker
+        # get ping topic and current number of pings
         parent_ping_topic = MQTTTopic.encode(
             envelope_type="gw",
             src=parent.publication_name,
@@ -319,9 +346,13 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
             message_type="gridworks-ping",
         )
         num_parent_pings = child_stats.num_received_by_topic[parent_ping_topic]
+
+        # Tell *parent* client we lost comm.
+        parent.force_mqtt_disconnect(parent.downstream_client)
+        # wait for child to get ping from parent when parent reconnects to mqtt
         await await_for(
             lambda: child_stats.num_received_by_topic[parent_ping_topic]
-            == num_parent_pings + 1,
+            > num_parent_pings,
             3,
             f"ERROR waiting for parent ping {parent_ping_topic}",
             err_str_f=child.summary_str,
@@ -344,6 +375,9 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
         assert child_comm_event_counts["gridworks.event.comm.peer.active"] == 2, err_str
         assert len(child_stats.comm_events) == 7, err_str
         assert child.event_persister.num_pending == 0, err_str
+        assert child.event_persister.num_persists == 6
+        assert child.event_persister.num_retrieves == 6
+        assert child.event_persister.num_clears == 6
 
         # Tell *both* clients we lost comm.
         parent.force_mqtt_disconnect(parent.downstream_client)
@@ -371,8 +405,12 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
 
         # wait for all events to be acked
         await await_for(
-            lambda: child.event_persister.num_pending == 0,
+            lambda: child.event_persister.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        assert child.event_persister.num_persists == 9
+        assert child.event_persister.num_retrieves == 9
+        assert child.event_persister.num_clears == 9

--- a/tests/test_proactor/test_comm/test_basic_comm.py
+++ b/tests/test_proactor/test_comm/test_basic_comm.py
@@ -166,16 +166,12 @@ async def test_basic_comm_child_first(request: Any) -> None:
 
         # wait for all events to be acked
         await await_for(
-            lambda: child.event_persister.num_pending == 0,
+            lambda: child.event_persister.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
-        if child.links.num_in_flight > 0:
-            import rich
-
-            rich.print(child.links.in_flight_events)
-        assert child.links.num_in_flight == 0
         # peer active event should never be persisted
         assert child.event_persister.num_persists == 6
         assert child.event_persister.num_retrieves == 6

--- a/tests/test_proactor/test_comm/test_basic_comm.py
+++ b/tests/test_proactor/test_comm/test_basic_comm.py
@@ -171,6 +171,10 @@ async def test_basic_comm_child_first(request: Any) -> None:
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,
         )
+        if child.links.num_in_flight > 0:
+            import rich
+
+            rich.print(child.links.in_flight_events)
         assert child.links.num_in_flight == 0
         # peer active event should never be persisted
         assert child.event_persister.num_persists == 6

--- a/tests/test_proactor/test_comm/test_basic_comm.py
+++ b/tests/test_proactor/test_comm/test_basic_comm.py
@@ -130,7 +130,8 @@ async def test_basic_comm_child_first(request: Any) -> None:
 
         # wait for all events to be acked
         await await_for(
-            lambda: child.event_persister.num_pending == 0,
+            lambda: child.event_persister.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for events to be acked",
             err_str_f=child.summary_str,

--- a/tests/test_proactor/test_comm/test_basic_comm.py
+++ b/tests/test_proactor/test_comm/test_basic_comm.py
@@ -321,7 +321,13 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
                 3,  # child connect, subscribe, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
         # Tell *child* client we lost comm.
         child.force_mqtt_disconnect(child.upstream_client)
@@ -367,7 +373,13 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
                 4,  # child disconnect, connect, subscribe, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
         # get ping topic and current number of pings
         parent_ping_topic = MQTTTopic.encode(
@@ -428,7 +440,13 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
                 4,  # parent disconnect, connect, subscribe, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
         # Tell *both* clients we lost comm.
         parent.force_mqtt_disconnect(parent.downstream_client)
@@ -479,4 +497,10 @@ async def test_basic_parent_comm_loss(request: Any) -> None:
                 4,  # parent disconnect, connect, subscribe, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -9,6 +9,8 @@ from gwproactor_test import LiveTest, await_for
 
 @pytest.mark.asyncio
 async def test_in_flight_happy_path(request: Any) -> None:
+    """Generate a bunch of events. While they are being acked generate a bunch
+    more. Verify the child has not persisted any of them."""
     async with LiveTest(start_child=True, start_parent=True, request=request) as h:
         child = h.child
         child_link = child.links.link(child.upstream_client)
@@ -62,7 +64,7 @@ async def test_in_flight_happy_path(request: Any) -> None:
         # generate a "bunch" of events, but not more than are allowed in-flight
         a_bunch = floor(child.settings.proactor.num_inflight_events * 0.8)
         exp_parent_events = parent.links.num_pending + 2 * a_bunch
-        exp_child_events = child.event_persister.num_persists
+        child_startup_persists = child.event_persister.num_persists
 
         h.child.delimit(f"Generating {a_bunch} events")
         for i in range(a_bunch):
@@ -110,7 +112,110 @@ async def test_in_flight_happy_path(request: Any) -> None:
         )
         # child should have persisted no new events
         child.assert_events_at_rest(
-            num_persists=exp_child_events,
+            num_persists=child_startup_persists,
+            all_clear=True,
+            tag="child",
+            err_str=h.summary_str(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_in_flight_overflow(request: Any) -> None:
+    """Generate more events than fit "in-fight". Verify persisted as expected
+    and reach their destination without timeouts.
+    """
+
+    # Start parent and child and wait for them to be at rest
+    async with LiveTest(start_child=True, start_parent=True, request=request) as h:
+        child = h.child
+        child_link = child.links.link(child.upstream_client)
+        parent = h.parent
+        parent_link = parent.links.link(parent.downstream_client)
+
+        # wait for all events to be at rest
+        exp_child_startup_events = sum(
+            [
+                1,  # child startup
+                2,  # child connect, substribe
+                1,  # child2 peer active
+            ]
+        )
+        exp_parent_startup_events = sum(
+            [
+                exp_child_startup_events,
+                1,  # parent startup
+                2,  # parent connect, subscribe
+                1,  # child1 peer active
+            ]
+        )
+        await await_for(
+            lambda: child_link.active() and child.events_at_rest(),
+            1,
+            "ERROR waiting for child events upload",
+            err_str_f=h.summary_str,
+        )
+        await await_for(
+            lambda: parent_link.active()
+            and parent.events_at_rest(num_pending=exp_parent_startup_events),
+            1,
+            f"ERROR waiting for parent to persist {exp_parent_startup_events} events",
+            err_str_f=h.summary_str,
+        )
+        parent.assert_events_at_rest(
+            num_pending=exp_parent_startup_events,
+            num_persists=exp_parent_startup_events,
+            all_pending=True,
+            tag="parent",
+            err_str=h.summary_str(),
+        )
+        child.assert_events_at_rest(
+            # child will not persist peer active event
+            num_persists=exp_child_startup_events - 1,
+            all_clear=True,
+            tag="child",
+            err_str=h.summary_str(),
+        )
+
+        # generate more events than fit in the pipe
+        a_bunch = child.settings.proactor.num_inflight_events * 2
+        exp_parent_events = parent.links.num_pending + a_bunch
+        exp_child_persists = (
+            child.event_persister.num_persists
+            + a_bunch
+            - child.settings.proactor.num_inflight_events
+        )
+
+        h.child.delimit(f"Generating {a_bunch} events")
+        for i in range(a_bunch):
+            child.generate_event(
+                DBGEvent(Command=DBGPayload(), Msg=f"event {i+1} / {a_bunch}")
+            )
+        last_in_flight = child.links.num_in_flight
+
+        def _child_got_more_acks() -> bool:
+            return child.links.num_in_flight < last_in_flight
+
+        # now wait for all events to rest
+        await await_for(
+            lambda: child.events_at_rest()
+            and parent.events_at_rest(num_pending=exp_parent_events),
+            1,
+            "ERROR waiting for child events upload",
+            err_str_f=h.summary_str,
+        )
+        parent.assert_events_at_rest(
+            num_pending=exp_parent_events,
+            num_persists=exp_parent_events,
+            all_pending=True,
+            tag="parent",
+            err_str=h.summary_str(),
+        )
+        # child should have persisted no new events
+        child.assert_events_at_rest(
+            num_persists=exp_child_persists,
+            # overflow events generated without loss of comm do not need to be
+            # retrieved
+            num_retrieves=exp_child_startup_events - 1,
             all_clear=True,
             tag="child",
             err_str=h.summary_str(),

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -1,10 +1,155 @@
+import logging
 from math import floor
-from typing import Any
+from typing import Any, Optional
 
 import pytest
+from gwproto.messages import Ack
 
+from gwproactor.links import StateName
 from gwproactor.message import DBGEvent, DBGPayload
 from gwproactor_test import LiveTest, await_for
+
+
+def assert_acks_consistent(
+    h: LiveTest,
+    *,
+    print_summary: bool = False,
+    print_all: bool = False,
+    log_level: int = logging.ERROR,
+) -> None:
+    full_s = f"\n\nParent paused acks: {len(h.parent.needs_ack)}\n"
+    summary_s = full_s
+    needs_ack_set: set[str] = set()
+    for i, needs_ack in enumerate(h.parent.needs_ack):
+        ack = needs_ack.message.Payload
+        if not isinstance(ack, Ack):
+            raise ValueError(f"WHOOPS: {type(ack)}")  # noqa: TRY004
+        if ack.AckMessageID in h.child.links.in_flight_events:
+            loc_s = "in-flight"
+        elif ack.AckMessageID in h.child.event_persister.pending_ids():
+            loc_s = "pending"
+        else:
+            loc_s = "*UKNONWN*"
+        full_s += f"  {i+1:3d} / {len(h.parent.needs_ack):3d}  {ack.AckMessageID[:8]}  {loc_s}\n"
+        needs_ack_set.add(ack.AckMessageID)
+    s = f"Child in-flight events: {h.child.links.num_in_flight}\n"
+    full_s += s
+    summary_s += s
+    for i, (event_id, event) in enumerate(h.child.links.in_flight_events.items()):
+        if event_id != event.MessageId:
+            raise ValueError(f"WHOOPS 1 {event_id} != {event.MessageId}")
+        full_s += f"  {i+1:3d} / {h.child.links.num_in_flight:3d}  {event_id[:8]}\n"
+    s = f"Child pending events: {h.child.links.num_pending}\n"
+    full_s += s
+    summary_s += s
+    for i, event_id in enumerate(h.child.event_persister.pending_ids()):
+        full_s += f"  {i+1:3d} / {h.child.links.num_pending:3d}  {event_id[:8]}\n"
+    in_flight_set: set[str] = set(h.child.links.in_flight_events.keys())
+    pending_set: set[str] = set(h.child.event_persister.pending_ids())
+    error_s = ""
+    if not in_flight_set.issubset(needs_ack_set):
+        in_flight_not_in_needs_ack_set: set[str] = in_flight_set.difference(
+            needs_ack_set
+        )
+        error_s += f"Child in-flight events not in needs ack: {len(in_flight_not_in_needs_ack_set)}\n"
+        for i, event_id in enumerate(in_flight_not_in_needs_ack_set):
+            error_s += f"  {i+1:3d} / {len(in_flight_not_in_needs_ack_set):3d}  {event_id[:8]}\n"
+    if not pending_set.issubset(needs_ack_set):
+        pending_not_in_needs_ack_set: set[str] = pending_set.difference(needs_ack_set)
+        error_s += f"Child pending events not in needs ack: {len(pending_not_in_needs_ack_set)}\n"
+        for i, event_id in enumerate(pending_not_in_needs_ack_set):
+            error_s += (
+                f"  {i+1:3d} / {len(pending_not_in_needs_ack_set):3d}  {event_id[:8]}\n"
+            )
+    needs_ack_not_in_events = needs_ack_set - (in_flight_set | pending_set)
+    if needs_ack_not_in_events:
+        error_s += (
+            f"Parent needs_ack not in child events: {len(needs_ack_not_in_events)}\n"
+        )
+        for i, event_id in enumerate(needs_ack_not_in_events):
+            error_s += (
+                f"  {i+1:3d} / {len(needs_ack_not_in_events):3d}  {event_id[:8]}\n"
+            )
+    if error_s:
+        raise ValueError(f"ERROR. Acks inconsistent\n{full_s}\n{error_s}\n")
+    consistent_s = "Acks CONSISTENT\n"
+    full_s += consistent_s
+    summary_s += consistent_s
+
+    if print_all:
+        h.child.logger.log(log_level, full_s)
+    elif print_summary:
+        h.child.logger.log(log_level, summary_s)
+
+
+async def await_quiescent_connections(
+    h: LiveTest,
+    exp_child_persists: Optional[int] = None,
+    exp_parent_pending: Optional[int] = None,
+    exp_parent_persists: Optional[int] = None,
+) -> None:
+    child = h.child
+    child_link = child.links.link(child.upstream_client)
+    parent = h.parent
+    parent_link = parent.links.link(parent.downstream_client)
+
+    # wait for all events to be at rest
+    exp_child_persists = (
+        exp_child_persists
+        if exp_child_persists is not None
+        else sum(
+            [
+                1,  # child startup
+                2,  # child connect, substribe
+            ]
+        )
+    )
+
+    exp_parent_pending = (
+        exp_parent_pending
+        if exp_parent_pending is not None
+        else (
+            sum(
+                [
+                    exp_child_persists,
+                    1,  # child peer active
+                    1,  # parent startup
+                    3,  # parent connect, subscribe, peer active
+                ]
+            )
+        )
+    )
+    exp_parent_persists = (
+        exp_parent_persists if exp_parent_persists is not None else exp_parent_pending
+    )
+    await await_for(
+        lambda: child_link.active() and child.events_at_rest(),
+        1,
+        "ERROR waiting for child events upload",
+        err_str_f=h.summary_str,
+    )
+    await await_for(
+        lambda: parent_link.active()
+        and parent.events_at_rest(num_pending=exp_parent_pending),
+        1,
+        f"ERROR waiting for parent to persist {exp_parent_pending} events",
+        err_str_f=h.summary_str,
+    )
+    parent.assert_event_counts(
+        num_pending=exp_parent_pending,
+        num_persists=exp_parent_persists,
+        num_clears=0,
+        num_retrieves=0,
+        tag="parent",
+        err_str=h.summary_str(),
+    )
+    child.assert_event_counts(
+        # child will not persist peer active event
+        num_persists=exp_child_persists,
+        all_clear=True,
+        tag="child",
+        err_str=h.summary_str(),
+    )
 
 
 @pytest.mark.asyncio
@@ -12,61 +157,16 @@ async def test_in_flight_happy_path(request: Any) -> None:
     """Generate a bunch of events. While they are being acked generate a bunch
     more. Verify the child has not persisted any of them."""
     async with LiveTest(start_child=True, start_parent=True, request=request) as h:
-        child = h.child
-        child_link = child.links.link(child.upstream_client)
-        parent = h.parent
-        parent_link = parent.links.link(parent.downstream_client)
+        await await_quiescent_connections(h)
 
-        # wait for all events to be at rest
-        exp_child_events = sum(
-            [
-                1,  # child startup
-                2,  # child connect, substribe
-                1,  # child2 peer active
-            ]
-        )
-        exp_parent_events = sum(
-            [
-                exp_child_events,
-                1,  # parent startup
-                2,  # parent connect, subscribe
-                1,  # child1 peer active
-            ]
-        )
-        await await_for(
-            lambda: child_link.active() and child.events_at_rest(),
-            1,
-            "ERROR waiting for child events upload",
-            err_str_f=h.summary_str,
-        )
-        await await_for(
-            lambda: parent_link.active()
-            and parent.events_at_rest(num_pending=exp_parent_events),
-            1,
-            f"ERROR waiting for parent to persist {exp_parent_events} events",
-            err_str_f=h.summary_str,
-        )
-        parent.assert_events_at_rest(
-            num_pending=exp_parent_events,
-            num_persists=exp_parent_events,
-            all_pending=True,
-            tag="parent",
-            err_str=h.summary_str(),
-        )
-        child.assert_events_at_rest(
-            # child will not persist peer active event
-            num_persists=exp_child_events - 1,
-            all_clear=True,
-            tag="child",
-            err_str=h.summary_str(),
-        )
+        child = h.child
+        parent = h.parent
 
         # generate a "bunch" of events, but not more than are allowed in-flight
         a_bunch = floor(child.settings.proactor.num_inflight_events * 0.8)
         exp_parent_events = parent.links.num_pending + 2 * a_bunch
         child_startup_persists = child.event_persister.num_persists
 
-        h.child.delimit(f"Generating {a_bunch} events")
         for i in range(a_bunch):
             child.generate_event(
                 DBGEvent(Command=DBGPayload(), Msg=f"event {i+1} / {a_bunch}")
@@ -77,7 +177,6 @@ async def test_in_flight_happy_path(request: Any) -> None:
             return child.links.num_in_flight < last_in_flight
 
         # now generate a "bunch" more, but each one after an ack
-        h.child.delimit(f"Generating {a_bunch} more events")
         for i in range(a_bunch):
             child.generate_event(
                 DBGEvent(
@@ -102,7 +201,7 @@ async def test_in_flight_happy_path(request: Any) -> None:
             "ERROR waiting for child events upload",
             err_str_f=h.summary_str,
         )
-        parent.assert_events_at_rest(
+        parent.assert_event_counts(
             num_pending=exp_parent_events,
             num_persists=exp_parent_events,
             all_pending=True,
@@ -110,7 +209,7 @@ async def test_in_flight_happy_path(request: Any) -> None:
             err_str=h.summary_str(),
         )
         # child should have persisted no new events
-        child.assert_events_at_rest(
+        child.assert_event_counts(
             num_persists=child_startup_persists,
             all_clear=True,
             tag="child",
@@ -126,56 +225,13 @@ async def test_in_flight_overflow(request: Any) -> None:
 
     # Start parent and child and wait for them to be at rest
     async with LiveTest(start_child=True, start_parent=True, request=request) as h:
-        child = h.child
-        child_link = child.links.link(child.upstream_client)
-        parent = h.parent
-        parent_link = parent.links.link(parent.downstream_client)
+        await await_quiescent_connections(h)
 
-        # wait for all events to be at rest
-        exp_child_startup_events = sum(
-            [
-                1,  # child startup
-                2,  # child connect, substribe
-                1,  # child2 peer active
-            ]
-        )
-        exp_parent_startup_events = sum(
-            [
-                exp_child_startup_events,
-                1,  # parent startup
-                2,  # parent connect, subscribe
-                1,  # child1 peer active
-            ]
-        )
-        await await_for(
-            lambda: child_link.active() and child.events_at_rest(),
-            1,
-            "ERROR waiting for child events upload",
-            err_str_f=h.summary_str,
-        )
-        await await_for(
-            lambda: parent_link.active()
-            and parent.events_at_rest(num_pending=exp_parent_startup_events),
-            1,
-            f"ERROR waiting for parent to persist {exp_parent_startup_events} events",
-            err_str_f=h.summary_str,
-        )
-        parent.assert_events_at_rest(
-            num_pending=exp_parent_startup_events,
-            num_persists=exp_parent_startup_events,
-            all_pending=True,
-            tag="parent",
-            err_str=h.summary_str(),
-        )
-        child.assert_events_at_rest(
-            # child will not persist peer active event
-            num_persists=exp_child_startup_events - 1,
-            all_clear=True,
-            tag="child",
-            err_str=h.summary_str(),
-        )
+        child = h.child
+        parent = h.parent
 
         # generate more events than fit in the pipe
+        initial_child_retrieves = child.event_persister.num_retrieves
         a_bunch = child.settings.proactor.num_inflight_events * 2
         exp_parent_events = parent.links.num_pending + a_bunch
         exp_child_persists = (
@@ -202,7 +258,7 @@ async def test_in_flight_overflow(request: Any) -> None:
             "ERROR waiting for child events upload",
             err_str_f=h.summary_str,
         )
-        parent.assert_events_at_rest(
+        parent.assert_event_counts(
             num_pending=exp_parent_events,
             num_persists=exp_parent_events,
             all_pending=True,
@@ -210,12 +266,563 @@ async def test_in_flight_overflow(request: Any) -> None:
             err_str=h.summary_str(),
         )
         # child should have persisted no new events
-        child.assert_events_at_rest(
+        child.assert_event_counts(
             num_persists=exp_child_persists,
             # overflow events generated without loss of comm do not need to be
             # retrieved
-            num_retrieves=exp_child_startup_events - 1,
+            num_retrieves=initial_child_retrieves,
             all_clear=True,
             tag="child",
             err_str=h.summary_str(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_in_flight_flowcontrol(request: Any) -> None:
+    """Test in-flight with carefully controlled acks. This is probably
+    duplication of the above less controlled tests, but seems worth having.
+    """
+
+    async with LiveTest(start_child=True, start_parent=True, request=request) as h:
+        await await_quiescent_connections(h)
+        child = h.child
+        parent = h.parent
+        parent.pause_acks()
+
+        # Walk through generating in-flight events.
+
+        # generate a "bunch" of events, but not more than are allowed in-flight
+        in_flight_buffer_size = child.settings.proactor.num_inflight_events
+        child_startup_persists = child.event_persister.num_persists
+        for i in range(in_flight_buffer_size):
+            child.generate_event(
+                DBGEvent(
+                    Command=DBGPayload(), Msg=f"event {i+1} / {in_flight_buffer_size}"
+                )
+            )
+            child.assert_event_counts(
+                num_pending=0,
+                num_in_flight=i + 1,
+                num_persists=child_startup_persists,
+                all_clear=True,
+            )
+        child.assert_event_counts(
+            num_pending=0,
+            num_in_flight=in_flight_buffer_size,
+            num_persists=child_startup_persists,
+            all_clear=True,
+        )
+        # paused acks: [50 in-flight]
+        await await_for(
+            lambda: len(parent.links.needs_ack) == in_flight_buffer_size,
+            1,
+            f"ERROR waiting for parent to have {in_flight_buffer_size} paused acks",
+        )
+        exp_parent_pending = 8 + in_flight_buffer_size
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after events generated",
+        )
+        assert_acks_consistent(h)
+
+        # Walk through generating more in-flight while in-flight buffer
+        # has room
+
+        # generate more events, one after each ack. None should be persisted.
+        for i in range(in_flight_buffer_size):
+            parent.release_acks(num_to_release=1)
+            exp_in_flight = in_flight_buffer_size - 1
+            await await_for(
+                lambda: child.links.num_in_flight == exp_in_flight,  # noqa: B023
+                3,
+                f"ERROR waiting for child to have {exp_in_flight} in flight, i:{i}",
+                err_str_f=h.summary_str,
+            )
+            child.assert_event_counts(
+                num_pending=0,
+                num_in_flight=exp_in_flight,
+                num_persists=child_startup_persists,
+                all_clear=True,
+            )
+            child.generate_event(
+                DBGEvent(
+                    Command=DBGPayload(),
+                    Msg=f"event {in_flight_buffer_size + i + 1} / {in_flight_buffer_size * 2}",
+                )
+            )
+            child.assert_event_counts(
+                num_pending=0,
+                num_in_flight=in_flight_buffer_size,
+                num_persists=child_startup_persists,
+                all_clear=True,
+            )
+        # paused acks: [50 in-flight]
+        await await_for(
+            lambda: len(parent.links.needs_ack) == in_flight_buffer_size,
+            1,
+            f"ERROR waiting for parent to have {in_flight_buffer_size} paused acks",
+        )
+        exp_parent_pending += in_flight_buffer_size
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after events generated",
+        )
+        assert_acks_consistent(h)
+
+        # Walk through overflowing the buffer
+
+        # Now overflow the in-flight buffer. Verify new events are persisted.
+        overflow_size = 10
+        for i in range(overflow_size):
+            child.generate_event(
+                DBGEvent(
+                    Command=DBGPayload(),
+                    Msg=f"overflow event {i + 1} / {overflow_size}",
+                )
+            )
+            child.assert_event_counts(
+                num_pending=i + 1,
+                num_in_flight=in_flight_buffer_size,
+                num_persists=child_startup_persists + i + 1,
+                num_retrieves=child_startup_persists,
+                num_clears=child_startup_persists,
+            )
+        # paused acks: [50 in-flight][10 persisted]
+        exp_needs_ack = in_flight_buffer_size + 10
+        await await_for(
+            lambda: len(parent.links.needs_ack) == exp_needs_ack,
+            1,
+            f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            err_str_f=h.summary_str,
+        )
+        exp_parent_pending += 10
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after overflow events generated",
+        )
+        assert_acks_consistent(h)
+        # Walk through mixing overflow and in flight.
+
+        # first with a small mix, release an 3 acks so we have some room in the
+        # in-flight buffer
+        acks_released = 3
+        parent.release_acks(num_to_release=acks_released)
+        await await_for(
+            lambda: child.links.num_in_flight == in_flight_buffer_size - acks_released,
+            1,
+            f"ERROR waiting for child to receive an {acks_released} acks",
+            err_str_f=h.summary_str,
+        )
+        child.assert_event_counts(
+            num_pending=overflow_size,
+            num_in_flight=in_flight_buffer_size - acks_released,
+            num_persists=child_startup_persists + overflow_size,
+            # acks should have been for in-flight events, not those persisted
+            num_retrieves=child_startup_persists,
+            num_clears=child_startup_persists,
+        )
+        # paused acks: [47 in-flight][10 persisted]
+        exp_needs_ack = in_flight_buffer_size + 10 - acks_released
+        await await_for(
+            lambda: len(parent.links.needs_ack) == exp_needs_ack,
+            1,
+            f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            err_str_f=h.summary_str,
+        )
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after small mix",
+        )
+        assert_acks_consistent(h)
+
+        # re-fill the in-flight buffer.
+        for i in range(acks_released):
+            child.generate_event(
+                DBGEvent(
+                    Command=DBGPayload(),
+                    Msg=f"refill event event {i}",
+                )
+            )
+            child.assert_event_counts(
+                num_pending=overflow_size,
+                num_in_flight=in_flight_buffer_size - acks_released + i + 1,
+                num_persists=child_startup_persists + overflow_size,
+                num_retrieves=child_startup_persists,
+                num_clears=child_startup_persists,
+            )
+        # paused acks: [47 in-flight][10 persisted][3 in-flight]
+        exp_needs_ack = in_flight_buffer_size + 10
+        await await_for(
+            lambda: len(parent.links.needs_ack) == exp_needs_ack,
+            1,
+            f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            err_str_f=h.summary_str,
+        )
+        exp_parent_pending += 3
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after in-flight refilled",
+        )
+        assert_acks_consistent(h)
+
+        # next event should be persisted
+        child.generate_event(
+            DBGEvent(
+                Command=DBGPayload(),
+                Msg="overflow event",
+            )
+        )
+        child.assert_event_counts(
+            num_pending=overflow_size + 1,
+            num_in_flight=in_flight_buffer_size,
+            num_persists=child_startup_persists + overflow_size + 1,
+            num_retrieves=child_startup_persists,
+            num_clears=child_startup_persists,
+        )
+        # paused acks: [47 in-flight][10 persisted][3 in-flight][1 persisted]
+        exp_needs_ack = in_flight_buffer_size + 11
+        await await_for(
+            lambda: len(parent.links.needs_ack) == exp_needs_ack,
+            1,
+            f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            err_str_f=h.summary_str,
+        )
+        exp_parent_pending += 1
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after overflow",
+        )
+        assert_acks_consistent(h)
+        # now generate a bigger mix
+        # release 30
+        acks_released = 30
+        exp_in_flight = in_flight_buffer_size - acks_released
+        parent.release_acks(num_to_release=acks_released)
+        await await_for(
+            lambda: child.links.num_in_flight == exp_in_flight,
+            1,
+            f"ERROR waiting for child to receive an {acks_released} acks",
+            err_str_f=h.summary_str,
+        )
+
+        # releases should not have changed persistence
+        child.assert_event_counts(
+            num_pending=overflow_size + 1,
+            num_in_flight=in_flight_buffer_size - acks_released,
+            num_persists=child_startup_persists + overflow_size + 1,
+            num_retrieves=child_startup_persists,
+            num_clears=child_startup_persists,
+        )
+        # paused acks: [17 in-flight][10 persisted][3 in-flight][1 persisted]
+        exp_needs_ack = in_flight_buffer_size + 11 - 30
+        await await_for(
+            lambda: len(parent.links.needs_ack) == exp_needs_ack,
+            1,
+            f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            err_str_f=h.summary_str,
+        )
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after overflow",
+        )
+        assert_acks_consistent(h)
+
+        # generate 60 events. 30 Should end up in-flight, and 30 persisted
+        exp_pending = 11
+        exp_persists = child_startup_persists + exp_pending
+        num_to_generate = 60
+        for i in range(num_to_generate):
+            child.generate_event(
+                DBGEvent(
+                    Command=DBGPayload(),
+                    Msg=f"refill event {i}",
+                )
+            )
+            if exp_in_flight < in_flight_buffer_size:
+                exp_in_flight += 1
+                # paused acks:
+                # [17 in-flight][10 persisted][3 in-flight][1 persisted][n in-flight]
+            else:
+                exp_pending += 1
+                exp_persists += 1
+                # paused acks:
+                # [17 in-flight][10 persisted][3 in-flight][1 persisted][30 in-flight][n persisted]
+            child.assert_event_counts(
+                num_pending=exp_pending,
+                num_in_flight=exp_in_flight,
+                num_persists=exp_persists,
+                num_retrieves=child_startup_persists,
+                num_clears=child_startup_persists,
+                tag=f"generated event {i+1} / {num_to_generate}  ",
+                err_str=h.summary_str(),
+            )
+        # paused acks:
+        # [17 in-flight][10 persisted][3 in-flight][1 persisted][30 in-flight][30 persisted]
+        exp_needs_ack = in_flight_buffer_size + 11 + 30
+        await await_for(
+            lambda: len(parent.links.needs_ack) == exp_needs_ack,
+            1,
+            f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            err_str_f=h.summary_str,
+        )
+        exp_parent_pending += 60
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after add 60 more",
+        )
+        assert_acks_consistent(h)
+
+        # release all the acks, group by group
+        exp_in_flight = in_flight_buffer_size
+        exp_pending = 41
+        exp_persists = child_startup_persists + exp_pending
+        exp_clears = child_startup_persists
+        for group_idx, (group_size, group_in_flight) in enumerate(
+            [
+                (17, True),
+                (10, False),
+                (3, True),
+                (1, False),
+                (30, True),
+                (30, False),
+            ]
+        ):
+            parent.release_acks(num_to_release=group_size)
+            if group_in_flight:
+                exp_in_flight -= group_size
+                await await_for(
+                    lambda: child.links.num_in_flight == exp_in_flight,  # noqa: B023
+                    1,
+                    f"ERROR waiting for in-flight to be {exp_in_flight} in flight acks",
+                    err_str_f=h.summary_str,
+                )
+            else:
+                exp_pending -= group_size
+                exp_clears += group_size
+                await await_for(
+                    lambda: child.links.num_pending == exp_pending,  # noqa: B023
+                    1,
+                    f"ERROR waiting for child to receive an {acks_released} acks",
+                )
+            child.assert_event_counts(
+                num_pending=exp_pending,
+                num_in_flight=exp_in_flight,
+                num_persists=exp_persists,
+                num_retrieves=child_startup_persists,
+                num_clears=exp_clears,
+                tag=f"group {group_idx}  group_size: {group_size}  group_in_flight: {group_in_flight}  ",
+                err_str=h.summary_str(),
+            )
+            exp_needs_ack -= group_size
+            await await_for(
+                lambda: len(parent.links.needs_ack) == exp_needs_ack,  # noqa: B023
+                1,
+                f"ERROR waiting for parent to have {exp_needs_ack} paused acks",
+            )
+            parent.assert_event_counts(
+                num_pending=exp_parent_pending,
+                all_pending=True,
+                tag=f"parent after add group {group_idx}  group_size: {group_size}  ",
+            )
+            assert_acks_consistent(h)
+
+        # all events should have been passed along.
+        child.assert_event_counts(
+            num_pending=0,
+            num_in_flight=0,
+            num_persists=exp_persists,
+            num_retrieves=child_startup_persists,
+            num_clears=exp_clears,
+            tag="Child events are clear",
+            err_str=h.summary_str(),
+        )
+        exp_parent_persists = sum(
+            [
+                4,  # parent startup, connect, subscribe, peer active
+                4,  # child startup, connect, subscribe, peer active
+                in_flight_buffer_size,  # first events
+                in_flight_buffer_size,  # flowing events whiles acks arrive
+                overflow_size,  # overflow events while acks arrive
+                4,  # refill buffer and overflow again
+                60,  # 60 more
+            ]
+        )
+        await await_for(
+            lambda: parent.event_persister.num_persists == exp_parent_persists,
+            1,
+            f"ERROR waiting for parent to persist {exp_parent_persists} events",
+        )
+        assert_acks_consistent(h)
+
+
+@pytest.mark.asyncio
+async def test_in_flight_comm_loss(request: Any) -> None:
+    """Verify that events are persisted if we lose comm while events are
+    in-flight"""
+
+    async with LiveTest(start_child=True, start_parent=True, request=request) as h:
+        await await_quiescent_connections(h)
+        child = h.child
+        upstream_link = child.links.link(child.upstream_client)
+        parent = h.parent
+        parent.pause_acks()
+
+        startup_persists = 3
+        exp_persists = startup_persists  # startup, connect, subscribed
+        child.assert_event_counts(num_persists=exp_persists, all_clear=True)
+        exp_parent_pending = 8
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag="parent after add group quiescent  ",
+        )
+
+        # generate some in-flight events
+        num_to_generate = 21
+        exp_in_flight = num_to_generate - 1
+        for i in range(exp_in_flight):
+            child.generate_event(DBGEvent(Command=DBGPayload(), Msg=f"event {i+1}"))
+        await await_for(
+            lambda: len(parent.needs_ack) == exp_in_flight,
+            1,
+            f"ERROR waiting for parent to have {exp_in_flight} paused acks",
+        )
+        child.assert_event_counts(
+            num_in_flight=exp_in_flight, num_persists=exp_persists, all_clear=True
+        )
+        exp_parent_pending += exp_in_flight
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag=f"parent after add group generating {exp_in_flight} events  ",
+        )
+        # generate one more event and time it out
+        child.set_ack_timeout_seconds(0.001)
+        child.generate_event(DBGEvent(Command=DBGPayload(), Msg=f"event {i+2}"))
+        exp_in_flight += 1
+        exp_pending = num_to_generate + 1  # generated + timeout
+        exp_persists += exp_pending
+        await await_for(
+            lambda: upstream_link.in_state(StateName.awaiting_peer),
+            1,
+            "ERROR waiting for child to see timeout",
+            err_str_f=h.summary_str,
+        )
+        exp_in_flight = 0
+        child.assert_event_counts(
+            num_pending=exp_pending,
+            num_in_flight=exp_in_flight,
+            num_persists=exp_persists,
+            num_clears=startup_persists,
+            num_retrieves=startup_persists,
+        )
+        exp_parent_pending += 1
+        await await_for(
+            lambda: parent.links.num_pending == exp_parent_pending,
+            1,
+            f"ERROR waiting for parent to have {exp_in_flight} paused acks",
+        )
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag=f"parent after add group generating {exp_in_flight} events  ",
+        )
+
+        # release acks, wait for events be at rest.
+        child.restore_ack_timeout_seconds()
+        parent.release_acks(num_to_release=-1)
+        exp_parent_pending += 2
+        # The parent will receive the generated events twice since they
+        # all time out and are then re-sent.
+        exp_parent_persists = exp_parent_pending + num_to_generate
+        await await_quiescent_connections(
+            h,
+            exp_child_persists=exp_persists,
+            exp_parent_pending=exp_parent_pending,
+            exp_parent_persists=exp_parent_persists,
+        )
+        exp_in_flight = 0
+        exp_pending = 0
+        child.assert_event_counts(
+            num_pending=0,
+            num_in_flight=0,
+            num_persists=exp_persists,
+            num_clears=exp_persists,
+            num_retrieves=exp_persists,
+        )
+
+
+@pytest.mark.asyncio
+async def test_in_flight_overflow_comm_loss(request: Any) -> None:
+    async with LiveTest(start_child=True, start_parent=True, request=request) as h:
+        await await_quiescent_connections(h)
+        child = h.child
+        upstream_link = child.links.link(child.upstream_client)
+        parent = h.parent
+        parent.pause_acks()
+
+        startup_persists = child.event_persister.num_persists
+        exp_child_persists = startup_persists
+        exp_parent_pending = parent.links.num_pending
+
+        # generate events, filling up the in-flight buffer and overflowing
+        num_to_generate = child.settings.proactor.num_inflight_events * 2
+        for i in range(num_to_generate - 1):
+            child.generate_event(DBGEvent(Command=DBGPayload(), Msg=f"event {i+1}"))
+        # generate one more and time it out
+        child.set_ack_timeout_seconds(0.001)
+        child.generate_event(DBGEvent(Command=DBGPayload(), Msg=f"event {i+2}"))
+        await await_for(
+            lambda: upstream_link.in_state(StateName.awaiting_peer),
+            1,
+            "ERROR waiting for child to see timeout",
+            err_str_f=h.summary_str,
+        )
+        exp_child_pending = num_to_generate + 1
+        exp_child_persists += exp_child_pending
+        child.assert_event_counts(
+            num_pending=exp_child_pending,
+            num_in_flight=0,
+            num_persists=exp_child_persists,
+            num_clears=startup_persists,
+            num_retrieves=startup_persists,
+        )
+
+        await await_for(
+            lambda: len(parent.needs_ack) == num_to_generate,
+            1,
+            f"ERROR waiting for parent to have {num_to_generate} paused acks",
+        )
+        exp_parent_pending += num_to_generate
+        parent.assert_event_counts(
+            num_pending=exp_parent_pending,
+            all_pending=True,
+            tag=f"parent after generating {num_to_generate} events  ",
+        )
+        # release acks, wait for events be at rest.
+        child.restore_ack_timeout_seconds()
+        parent.release_acks(num_to_release=-1)
+        exp_parent_pending += 2  # timeout and peer active
+        # The parent will receive the generated events twice since they
+        # all time out and are then re-sent.
+        exp_parent_persists = exp_parent_pending + num_to_generate
+        await await_quiescent_connections(
+            h,
+            exp_child_persists=exp_child_persists,
+            exp_parent_pending=exp_parent_pending,
+            exp_parent_persists=exp_parent_persists,
+        )
+        child.assert_event_counts(
+            num_pending=0,
+            num_in_flight=0,
+            num_persists=exp_child_persists,
+            all_clear=True,
         )

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -821,7 +821,7 @@ async def test_in_flight_flowcontrol(request: Any) -> None:
                 await await_for(
                     lambda: child.links.num_in_flight == exp_in_flight,  # noqa: B023
                     1,
-                    f"ERROR waiting for in-flight to be {exp_in_flight} in flight acks",
+                    f"ERROR waiting for {exp_in_flight} in-flight-events, group_size: {group_size}",
                     err_str_f=h.summary_str,
                 )
             else:
@@ -830,7 +830,7 @@ async def test_in_flight_flowcontrol(request: Any) -> None:
                 await await_for(
                     lambda: child.links.num_pending == exp_pending,  # noqa: B023
                     1,
-                    f"ERROR waiting for child to receive an {acks_released} acks",
+                    f"ERROR waiting for child to receive an {acks_released} acks, group_size: {group_size}",
                 )
             child.assert_event_counts(
                 num_pending=exp_pending,

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -341,6 +341,7 @@ async def test_in_flight_flowcontrol(request: Any) -> None:
         child = h.child
         parent = h.parent
         parent.pause_acks()
+        child.set_ack_timeout_seconds(100)  # please no timeouts while we are busy
 
         # Walk through generating in-flight events.
 

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -94,7 +94,6 @@ async def test_in_flight_happy_path(request: Any) -> None:
                 err_str_f=h.summary_str,
             )
             last_in_flight = child.links.num_in_flight
-            assert child.event_persister.num_persists == exp_child_events
         # now wait for all events to rest
         await await_for(
             lambda: child.events_at_rest()

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -1,0 +1,117 @@
+from math import floor
+from typing import Any
+
+import pytest
+
+from gwproactor.message import DBGEvent, DBGPayload
+from gwproactor_test import LiveTest, await_for
+
+
+@pytest.mark.asyncio
+async def test_in_flight_happy_path(request: Any) -> None:
+    async with LiveTest(start_child=True, start_parent=True, request=request) as h:
+        child = h.child
+        child_link = child.links.link(child.upstream_client)
+        parent = h.parent
+        parent_link = parent.links.link(parent.downstream_client)
+
+        # wait for all events to be at rest
+        exp_child_events = sum(
+            [
+                1,  # child startup
+                2,  # child connect, substribe
+                1,  # child2 peer active
+            ]
+        )
+        exp_parent_events = sum(
+            [
+                exp_child_events,
+                1,  # parent startup
+                2,  # parent connect, subscribe
+                1,  # child1 peer active
+            ]
+        )
+        await await_for(
+            lambda: child_link.active() and child.events_at_rest(),
+            1,
+            "ERROR waiting for child events upload",
+            err_str_f=h.summary_str,
+        )
+        await await_for(
+            lambda: parent_link.active()
+            and parent.events_at_rest(num_pending=exp_parent_events),
+            1,
+            f"ERROR waiting for parent to persist {exp_parent_events} events",
+            err_str_f=h.summary_str,
+        )
+        parent.assert_events_at_rest(
+            num_pending=exp_parent_events,
+            num_persists=exp_parent_events,
+            all_pending=True,
+            tag="parent",
+            err_str=h.summary_str(),
+        )
+        child.assert_events_at_rest(
+            # child will not persist peer active event
+            num_persists=exp_child_events - 1,
+            all_clear=True,
+            tag="child",
+            err_str=h.summary_str(),
+        )
+
+        # generate a "bunch" of events, but not more than are allowed in-flight
+        a_bunch = floor(child.settings.proactor.num_inflight_events * 0.8)
+        exp_parent_events = parent.links.num_pending + 2 * a_bunch
+        exp_child_events = child.event_persister.num_persists
+
+        h.child.delimit(f"Generating {a_bunch} events")
+        for i in range(a_bunch):
+            child.generate_event(
+                DBGEvent(Command=DBGPayload(), Msg=f"event {i+1} / {a_bunch}")
+            )
+        last_in_flight = child.links.num_in_flight
+
+        def _child_got_more_acks() -> bool:
+            return child.links.num_in_flight < last_in_flight
+
+        # now generate a "bunch" more, but each one after an ack
+        h.child.delimit(f"Generating {a_bunch} more events")
+        for i in range(a_bunch):
+            child.generate_event(
+                DBGEvent(
+                    Command=DBGPayload(), Msg=f"event {a_bunch + i+1} / {a_bunch * 2}"
+                )
+            )
+            last_in_flight = child.links.num_in_flight
+            assert last_in_flight > 0
+            await await_for(
+                lambda: _child_got_more_acks(),
+                1,
+                "ERROR waiting for child to receive some acks",
+                retry_duration=0.001,
+                err_str_f=h.summary_str,
+            )
+            last_in_flight = child.links.num_in_flight
+            assert child.event_persister.num_persists == exp_child_events
+        # now wait for all events to rest
+        await await_for(
+            lambda: child.events_at_rest()
+            and parent.events_at_rest(num_pending=exp_parent_events),
+            1,
+            "ERROR waiting for child events upload",
+            err_str_f=h.summary_str,
+        )
+        parent.assert_events_at_rest(
+            num_pending=exp_parent_events,
+            num_persists=exp_parent_events,
+            all_pending=True,
+            tag="parent",
+            err_str=h.summary_str(),
+        )
+        # child should have persisted no new events
+        child.assert_events_at_rest(
+            num_persists=exp_child_events,
+            all_clear=True,
+            tag="child",
+            err_str=h.summary_str(),
+        )

--- a/tests/test_proactor/test_comm/test_in_flight.py
+++ b/tests/test_proactor/test_comm/test_in_flight.py
@@ -491,7 +491,18 @@ async def test_in_flight_flowcontrol(request: Any) -> None:
     duplication of the above less controlled tests, but seems worth having.
     """
 
-    async with LiveTest(start_child=True, start_parent=True, request=request) as h:
+    # Please no timeouts while we are busy
+    child_settings = LiveTest.child_app_type().get_settings()
+    parent_settings = LiveTest.parent_app_type().get_settings()
+    child_settings.proactor.ack_timeout_seconds = 100
+    parent_settings.proactor.ack_timeout_seconds = 100
+    async with LiveTest(
+        start_child=True,
+        start_parent=True,
+        request=request,
+        child_app_settings=child_settings,
+        parent_app_settings=parent_settings,
+    ) as h:
         await await_quiescent_connections(h)
         child = h.child
         parent = h.parent

--- a/tests/test_proactor/test_comm/test_reupload.py
+++ b/tests/test_proactor/test_comm/test_reupload.py
@@ -1,4 +1,4 @@
-# ruff: noqa: ERA001
+# ruff: noqa: ERA001,PLR2004
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -59,7 +59,9 @@ async def test_reupload_basic(request: Any) -> None:
 
         # Wait for reuploading to complete
         await await_for(
-            lambda: reupload_counts.completed > 0,
+            lambda: reupload_counts.completed > 0
+            and child.links.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for re-upload to complete",
             err_str_f=h.summary_str,
@@ -69,6 +71,21 @@ async def test_reupload_basic(request: Any) -> None:
         assert child.links.num_reupload_pending == 0
         assert child.links.num_reuploaded_unacked == 0
         assert not child.links.reuploading()
+
+        assert child.event_persister.num_persists == 3
+        assert child.event_persister.num_retrieves == 3
+        assert child.event_persister.num_clears == 3
+
+        # parent should have persisted:
+        exp_events = sum(
+            [
+                1,  # parent startup
+                3,  # parent connect, subscribe, peer active
+                1,  # child startup
+                3,  # child connect, subscribe, peer active
+            ]
+        )
+        assert h.parent.event_persister.num_persists == exp_events
 
 
 @pytest.mark.asyncio
@@ -100,8 +117,7 @@ async def test_reupload_flow_control_simple(request: Any) -> None:
             err_str_f=h.summary_str,
         )
         # Some events should have been generated, and they should have all been sent
-        base_num_pending = child.links.num_pending
-        assert base_num_pending > 0
+        assert child.links.num_pending == 3
         assert child.links.num_reupload_pending == 0
         assert child.links.num_reuploaded_unacked == 0
         assert not child.links.reuploading()
@@ -115,9 +131,15 @@ async def test_reupload_flow_control_simple(request: Any) -> None:
                     Msg=f"event {i + 1} / {events_to_generate}",
                 )
             )
+            assert child.links.num_pending == 3 + i + 1
         child.logger.info(
             f"Generated {events_to_generate} events. Total pending events: {child.links.num_pending}"
         )
+        assert child.links.num_pending == (3 + events_to_generate)
+        assert child.links.num_in_flight == 0
+        assert child.event_persister.num_persists == (3 + events_to_generate)
+        assert child.event_persister.num_retrieves == 0
+        assert child.event_persister.num_clears == 0
 
         # Start parent, wait for connect.
         h.start_parent()
@@ -130,11 +152,27 @@ async def test_reupload_flow_control_simple(request: Any) -> None:
 
         # Wait for reupload to complete
         await await_for(
-            lambda: reupload_counts.completed > 0,
+            lambda: reupload_counts.completed > 0
+            and child.links.num_pending == 0
+            and child.links.num_in_flight == 0,
             1,
             "ERROR waiting for reupload to complete",
             err_str_f=h.summary_str,
         )
+        assert child.event_persister.num_persists == (3 + events_to_generate)
+        assert child.event_persister.num_retrieves == child.event_persister.num_persists
+        assert child.event_persister.num_clears == child.event_persister.num_persists
+        # parent should have persisted:
+        exp_events = sum(
+            [
+                1,  # parent startup
+                3,  # parent connect, subscribe, peer active
+                1,  # child startup
+                3,  # child connect, subscribe, peer active
+                events_to_generate,  # generated events
+            ]
+        )
+        assert h.parent.event_persister.num_persists == exp_events
 
 
 @pytest.mark.asyncio
@@ -167,8 +205,7 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
         # Some events should happened already, through the startup and mqtt connect process, and they should have
         # all been sent.
         # These events include: There are at least 3 non-generated events: startup, (mqtt connect, mqtt subscribed)/mqtt client.
-        base_num_pending = child_links.num_pending
-        assert base_num_pending > 0
+        assert child_links.num_pending == 3
         assert child_links.num_reupload_pending == 0
         assert child_links.num_reuploaded_unacked == 0
         assert not child_links.reuploading()
@@ -193,7 +230,11 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
             err_str_f=h.summary_str,
         )
 
-        assert child.links.num_pending == base_num_pending + events_to_generate
+        assert child.links.num_pending == 3 + events_to_generate
+        assert child.links.num_in_flight == 0
+        assert child.event_persister.num_persists == (3 + events_to_generate)
+        assert child.event_persister.num_retrieves == 0
+        assert child.event_persister.num_clears == 0
         assert child_links.num_reupload_pending == 0
         assert child_links.num_reuploaded_unacked == 0
         assert not child_links.reuploading()
@@ -236,7 +277,7 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
         # A "PeerActive" event is also pending but that is _not_ part of re-upload because it is
         # generated _after_ the peer is active (and therefore has its own ack timeout running, so does not need to
         # be managed by reupload).
-        last_num_to_reupload = events_to_generate + base_num_pending
+        last_num_to_reupload = events_to_generate + 3
         last_num_reuploaded_unacked = (
             child.settings.proactor.num_initial_event_reuploads
         )
@@ -252,8 +293,15 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
         )
         assert child_links.num_reuploaded_unacked == last_num_reuploaded_unacked, err_s
         assert child_links.num_reupload_pending == last_num_repuload_pending, err_s
-        assert child_links.num_pending == last_num_to_reupload
         assert child_links.reuploading()
+        assert child_links.num_pending == last_num_to_reupload
+        assert child.links.num_in_flight == 1
+        assert child.event_persister.num_persists == last_num_to_reupload
+        assert (
+            child.event_persister.num_retrieves
+            == child.settings.proactor.num_initial_event_reuploads
+        )
+        assert child.event_persister.num_clears == 0
 
         parent_ack_topic = MQTTTopic.encode(
             "gw",
@@ -270,12 +318,41 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
         #
         end_time = time.time() + 5
         loop_count_dbg = 0
+        loop_path_dbg = 0
         acks_released = 0
+        last_pending = child_links.num_pending
+        last_in_flight = child.links.num_in_flight
+        assert last_in_flight == 1
+        last_persists = child.event_persister.num_persists
+        initial_persists = child.event_persister.num_persists
+        last_retrieves = child.event_persister.num_retrieves
+        last_clears = child.event_persister.num_clears
+        curr_num_reuploaded_unacked = child_links.num_reuploaded_unacked
+        curr_num_repuload_pending = child_links.num_reupload_pending
+        curr_num_to_reuplad = curr_num_reuploaded_unacked + curr_num_repuload_pending
+
+        def _loop_dbg(tag: str = "") -> str:
+            return (
+                f"ack loop: {loop_count_dbg} ({acks_released}): "
+                f"reupload: ({last_num_reuploaded_unacked}, {last_num_repuload_pending}) -> "
+                f"({curr_num_reuploaded_unacked}, {curr_num_repuload_pending})  "
+                f"in-flight/pending: ({last_in_flight}, {last_pending}) -> "
+                f"({child.links.num_in_flight}, {child_links.num_pending})  "
+                f"persister: ({last_persists}, {last_retrieves}, {last_clears}) -> "
+                f"({child.event_persister.num_persists}, "
+                f"{child.event_persister.num_retrieves}, "
+                f"{child.event_persister.num_clears})  "
+                f"loop_path_dbg: 0x{loop_path_dbg:08X}{f'  [{tag}]' if tag else ''}"
+            )
+
+        assert child_links.num_pending == last_num_to_reupload
+        child.logger.info(_loop_dbg("pre-loop"))
         while child_links.reuploading() and time.time() < end_time:
             loop_path_dbg = 0
             loop_count_dbg += 1
 
             # release one ack
+            assert child_links.num_pending == last_pending
             acks_released += h.parent.release_acks(num_to_release=1)
 
             # Wait for child to receive an ack
@@ -295,12 +372,37 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
             curr_num_to_reuplad = (
                 curr_num_reuploaded_unacked + curr_num_repuload_pending
             )
+
+            # There should be no persisting during reupload.
+            assert child.event_persister.num_persists == initial_persists
+
+            # The peer active event is not part of re-upload, and might get
+            # acked during the re-upload. There should be no other in-flight
+            # events.
+            if child.links.num_in_flight not in (1, 0):
+                raise ValueError(
+                    f"ERROR got unexpected num_in_flight "
+                    f"({child.links.num_in_flight}). Expected 1 or 0"
+                )
+            # ack of a re-upload event
+            if child.links.num_in_flight == 1:
+                assert child_links.num_pending == last_pending - 1
+                assert child.event_persister.num_retrieves == last_retrieves + 1
+                assert child.event_persister.num_clears == last_clears + 1
+            # ack of the peer-active, in-flight event
+            elif last_in_flight == 1 and child.links.num_in_flight == 0:
+                assert child_links.num_pending == last_pending
+                assert child.event_persister.num_retrieves == last_retrieves
+                assert child.event_persister.num_clears == last_clears
+
+            # ack of the peer active event
             if curr_num_to_reuplad == last_num_to_reupload:
-                # loop_path_dbg |= 0x00000001
+                loop_path_dbg |= 0x00000001
                 assert curr_num_reuploaded_unacked == last_num_reuploaded_unacked
                 assert curr_num_repuload_pending == last_num_repuload_pending
+            # ack of a re-upload event
             elif curr_num_to_reuplad == last_num_to_reupload - 1:
-                # loop_path_dbg |= 0x00000002
+                loop_path_dbg |= 0x00000002
                 if curr_num_reuploaded_unacked == last_num_reuploaded_unacked:
                     assert curr_num_repuload_pending == last_num_repuload_pending - 1
                 else:
@@ -318,16 +420,15 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
                     f"({curr_num_reuploaded_unacked}, {curr_num_repuload_pending})"
                 )
 
-            child.logger.info(
-                f"ack loop: {loop_count_dbg} / {acks_released}:"
-                f"({last_num_reuploaded_unacked}, {last_num_repuload_pending}) -> "
-                f"({curr_num_reuploaded_unacked}, {curr_num_repuload_pending})"
-                f" loop_path_dbg: 0x{loop_path_dbg:08X}"
-            )
-
+            child.logger.info(_loop_dbg("iteration complete"))
             last_num_to_reupload = curr_num_to_reuplad
             last_num_reuploaded_unacked = curr_num_reuploaded_unacked
             last_num_repuload_pending = curr_num_repuload_pending
+            last_pending = child_links.num_pending
+            last_in_flight = child.links.num_in_flight
+            last_persists = child.event_persister.num_persists
+            last_retrieves = child.event_persister.num_retrieves
+            last_clears = child.event_persister.num_clears
 
         assert not child_links.reuploading()
 
@@ -449,8 +550,11 @@ async def test_reupload_errors(request: Any) -> None:
             "ERROR waiting for child to connect to mqtt",
             err_str_f=_err_str,
         )
-        base_num_pending = child_links.num_pending
-        assert base_num_pending > 0
+        assert child.links.num_pending == 3
+        assert child.links.num_in_flight == 0
+        assert child.event_persister.num_persists == 3
+        assert child.event_persister.num_retrieves == 0
+        assert child.event_persister.num_clears == 0
         assert child_links.num_reupload_pending == 0
         assert child_links.num_reuploaded_unacked == 0
         assert not child_links.reuploading()
@@ -462,6 +566,11 @@ async def test_reupload_errors(request: Any) -> None:
         generator.generate(num_ok=10)
         generator.generate(num_missing=10)
         generator.generate(num_ok=10)
+        assert child.links.num_pending == 63
+        assert child.links.num_in_flight == 0
+        assert child.event_persister.num_persists == 63
+        assert child.event_persister.num_retrieves == 0
+        assert child.event_persister.num_clears == 0
 
         h.start_parent()
         await await_for(
@@ -473,10 +582,17 @@ async def test_reupload_errors(request: Any) -> None:
 
         # Wait for reupload to complete
         await await_for(
-            lambda: reupload_counts.completed > 0,
+            lambda: reupload_counts.completed > 0
+            and child.links.num_pending == 0
+            and child.links.num_in_flight == 0,
             3,
             "ERROR waiting for reupload to complete",
             err_str_f=_err_str,
         )
         assert reupload_counts.started == reupload_counts.completed
-        assert parent.stats.num_events_received >= base_num_pending + 60
+        assert parent.stats.num_events_received == 64
+        assert child.links.num_pending == 0
+        assert child.links.num_in_flight == 0
+        assert child.event_persister.num_persists == 63
+        assert child.event_persister.num_retrieves == 63
+        assert child.event_persister.num_clears == 63

--- a/tests/test_proactor/test_comm/test_reupload.py
+++ b/tests/test_proactor/test_comm/test_reupload.py
@@ -321,7 +321,6 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
             h.child.subscription_name,
             "gridworks-ack",
         )
-        acks_received_by_child = child.stats.num_received_by_topic[parent_ack_topic]
 
         # Release acks one by one.
         #
@@ -368,9 +367,10 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
             acks_released += h.parent.release_acks(num_to_release=1)
 
             # Wait for child to receive an ack
+            last_events = last_in_flight + last_pending
             await await_for(
-                lambda: child.stats.num_received_by_topic[parent_ack_topic]
-                == acks_received_by_child + acks_released,  # noqa: B023
+                lambda: child.links.num_pending + child.links.num_in_flight
+                == last_events - 1,  # noqa: B023
                 timeout=1,
                 tag=(
                     "ERROR waiting for child to receive ack "

--- a/tests/test_proactor/test_comm/test_reupload.py
+++ b/tests/test_proactor/test_comm/test_reupload.py
@@ -85,7 +85,13 @@ async def test_reupload_basic(request: Any) -> None:
                 3,  # child connect, subscribe, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
 
 @pytest.mark.asyncio
@@ -172,7 +178,13 @@ async def test_reupload_flow_control_simple(request: Any) -> None:
                 events_to_generate,  # generated events
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_proactor/test_comm/test_reupload.py
+++ b/tests/test_proactor/test_comm/test_reupload.py
@@ -252,7 +252,7 @@ async def test_reupload_flow_control_detail(request: Any) -> None:
         )
         assert child_links.num_reuploaded_unacked == last_num_reuploaded_unacked, err_s
         assert child_links.num_reupload_pending == last_num_repuload_pending, err_s
-        assert child_links.num_pending == last_num_to_reupload + 1
+        assert child_links.num_pending == last_num_to_reupload
         assert child_links.reuploading()
 
         parent_ack_topic = MQTTTopic.encode(

--- a/tests/test_proactor/test_comm/test_timeout.py
+++ b/tests/test_proactor/test_comm/test_timeout.py
@@ -142,7 +142,13 @@ async def test_response_timeout(request: Any) -> None:
                 2,  # child timeout, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
 
 @pytest.mark.asyncio
@@ -208,7 +214,13 @@ async def test_ping(request: Any) -> None:
                 3,  # child connect, subscribe, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
         # Test that ping sent peridoically if no messages sent
         start_pings_from_parent = stats.num_received_by_topic[pings_from_parent_topic]
@@ -304,7 +316,13 @@ async def test_ping(request: Any) -> None:
                 reps,  # dbg events
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )
 
         parent.pause_acks()
         await await_for(
@@ -337,4 +355,10 @@ async def test_ping(request: Any) -> None:
                 2,  # child timeout, peer active
             ]
         )
-        assert h.parent.event_persister.num_persists == exp_events
+        # wait for parent to finish persisting
+        await await_for(
+            lambda: h.parent.event_persister.num_persists == exp_events,
+            3,
+            f"ERROR waiting for parent to finish persisting {exp_events} events",
+            err_str_f=h.summary_str,
+        )

--- a/tests/test_proactor/test_comm/test_tree.py
+++ b/tests/test_proactor/test_comm/test_tree.py
@@ -95,12 +95,10 @@ async def test_tree_no_parent(request: Any) -> None:
         assert child2.links.num_in_flight == 0
         # child2 never persists its own peer active, and whether it persists
         # admin events depends on when child1 link goes active
-        assert 3 <= child2.event_persister.num_persists <= 5
-        assert child2.event_persister.num_persists == 5
-        assert (
-            child2.event_persister.num_retrieves == child2.event_persister.num_persists
-        )
-        assert child2.event_persister.num_clears == child2.event_persister.num_persists
+        persister2 = child2.event_persister
+        assert 3 <= persister2.num_persists <= 5
+        assert persister2.num_retrieves == persister2.num_persists
+        assert persister2.num_clears == persister2.num_persists
 
 
 @pytest.mark.asyncio
@@ -179,12 +177,10 @@ async def test_tree_message_exchange(request: Any) -> None:
         assert child2.links.num_in_flight == 0
         # child2 never persists its own peer active, and whether it persists
         # admin events depends on when child1 link goes active
-        assert 3 <= child2.event_persister.num_persists <= 5
-        assert child2.event_persister.num_persists == 5
-        assert (
-            child2.event_persister.num_retrieves == child2.event_persister.num_persists
-        )
-        assert child2.event_persister.num_clears == child2.event_persister.num_persists
+        persister2 = child2.event_persister
+        assert 3 <= persister2.num_persists <= 5
+        assert persister2.num_retrieves == persister2.num_persists
+        assert persister2.num_clears == persister2.num_persists
 
 
 @pytest.mark.asyncio
@@ -273,8 +269,8 @@ async def test_tree_parent_comm(request: Any) -> None:
         # child2 never persists its own peer active, and whether it persists
         # admin events depends on when child1 link goes active
         assert 3 <= persister2.num_persists <= 5
-        assert persister2.num_persists == 5
         assert persister2.num_retrieves == persister2.num_persists
+        assert persister2.num_clears == persister2.num_persists
 
 
 @pytest.mark.asyncio

--- a/tests/test_proactor/test_comm/test_tree.py
+++ b/tests/test_proactor/test_comm/test_tree.py
@@ -383,6 +383,5 @@ async def test_tree_event_forward(request: Any) -> None:
         # child2 never persists its own peer active, and whether it persists
         # admin events depends on when child1 link goes active
         assert 3 <= persister2.num_persists <= 5
-        assert persister2.num_persists == 5
         assert persister2.num_retrieves == persister2.num_persists
         assert persister2.num_clears == persister2.num_persists

--- a/tests/test_proactor/test_comm/test_tree.py
+++ b/tests/test_proactor/test_comm/test_tree.py
@@ -162,8 +162,10 @@ async def test_tree_message_exchange(request: Any) -> None:
             ]
         )
         await await_for(
-            lambda: child2.links.num_pending == 0
-            and child1.links.num_pending == exp_child1_events,
+            lambda: child1.links.num_pending == exp_child1_events
+            and child1.links.num_in_flight == 0
+            and child2.links.num_pending == 0
+            and child2.links.num_in_flight == 0,
             1,
             f"ERROR waiting for child1 to receive {exp_child1_events} events",
             err_str_f=h.summary_str,
@@ -242,7 +244,9 @@ async def test_tree_parent_comm(request: Any) -> None:
         )
         await await_for(
             lambda: h.child1.links.num_pending == 0
+            and h.child1.links.num_in_flight == 0
             and h.child2.links.num_pending == 0
+            and h.child2.links.num_in_flight == 0
             and h.parent.links.num_pending == exp_parent_events,
             1,
             f"ERROR waiting for parent to persist {exp_parent_events} events",
@@ -346,7 +350,9 @@ async def test_tree_event_forward(request: Any) -> None:
         )
         await await_for(
             lambda: h.child1.links.num_pending == 0
+            and h.child1.links.num_in_flight == 0
             and h.child2.links.num_pending == 0
+            and h.child2.links.num_in_flight == 0
             and h.parent.links.num_pending == exp_parent_events,
             1,
             f"ERROR waiting for parent to persist {exp_parent_events} events",

--- a/tests/test_proactor/test_comm/test_tree.py
+++ b/tests/test_proactor/test_comm/test_tree.py
@@ -275,7 +275,6 @@ async def test_tree_parent_comm(request: Any) -> None:
         assert 3 <= persister2.num_persists <= 5
         assert persister2.num_persists == 5
         assert persister2.num_retrieves == persister2.num_persists
-        assert persister2.num_clears == persister2.num_persists
 
 
 @pytest.mark.asyncio

--- a/tests/test_proactor/test_comm/test_tree.py
+++ b/tests/test_proactor/test_comm/test_tree.py
@@ -29,7 +29,9 @@ async def test_tree_no_parent(request: Any) -> None:
         # start child 1
         h.start_child1()
         await await_for(
-            lambda: link1to2.active_for_send() and link1toAtn.active_for_send(),
+            lambda: link1to2.active_for_send()
+            and link1toAtn.active_for_send()
+            and child1.links.num_pending == 7,
             1,
             "ERROR waiting child1 links to be active_for_send",
             err_str_f=h.summary_str,
@@ -42,6 +44,12 @@ async def test_tree_no_parent(request: Any) -> None:
         assert counts1toAtn["gridworks.event.comm.mqtt.connect"] == 1
         assert counts1toAtn["gridworks.event.comm.mqtt.fully.subscribed"] == 1
         assert len(stats1toAtn.comm_events) == 2
+        # 1 startup event + (atn, admin, scada2) x (connect, subscribed)
+        assert child1.links.num_pending == 7
+        assert child1.links.num_in_flight == 0
+        assert child1.event_persister.num_persists == 7
+        assert child1.event_persister.num_retrieves == 0
+        assert child1.event_persister.num_clears == 0
 
         # add child 2
         h.add_child2()
@@ -56,7 +64,14 @@ async def test_tree_no_parent(request: Any) -> None:
         # start child 2
         h.start_child2()
         await await_for(
-            lambda: link1to2.active() and link2to1.active(),
+            lambda: link1to2.active()
+            and link2to1.active()
+            and child2.links.num_in_flight == 0
+            and child2.links.num_in_flight == 0
+            # 7 child1 events +
+            # 1 child1 peer active +
+            # 6 child2 startup, (admin, scada1) x (connect, subscribe), peer active
+            and child1.links.num_pending == 14,
             1,
             "ERROR waiting child2 links to be active",
             err_str_f=h.summary_str,
@@ -69,6 +84,23 @@ async def test_tree_no_parent(request: Any) -> None:
         assert counts2to1["gridworks.event.comm.mqtt.connect"] == 1
         assert counts2to1["gridworks.event.comm.mqtt.fully.subscribed"] == 1
         assert len(stats2to1.comm_events) == 3
+
+        assert child1.links.num_pending == 14
+        assert child1.links.num_in_flight == 0
+        assert child1.event_persister.num_persists == 14
+        assert child1.event_persister.num_retrieves == 0
+        assert child1.event_persister.num_clears == 0
+
+        assert child2.links.num_pending == 0
+        assert child2.links.num_in_flight == 0
+        # child2 never persists its own peer active, and whether it persists
+        # admin events depends on when child1 link goes active
+        assert 3 <= child2.event_persister.num_persists <= 5
+        assert child2.event_persister.num_persists == 5
+        assert (
+            child2.event_persister.num_retrieves == child2.event_persister.num_persists
+        )
+        assert child2.event_persister.num_clears == child2.event_persister.num_persists
 
 
 @pytest.mark.asyncio
@@ -117,6 +149,41 @@ async def test_tree_message_exchange(request: Any) -> None:
         assert h.child2_app.prime_actor.relays == {relay_name: True}
         assert h.child_app.prime_actor.relays.TotalChangeMismatches == 0
 
+        # wait for all events to be at rest
+        exp_child1_events = sum(
+            [
+                1,  # child1 startup
+                6,  # child1 (parent, child2, admin) x (connect, subscribe)
+                1,  # child1 peer active
+                2,  # relay set, relay report
+                1,  # child2 startup
+                4,  # child2 (child1, admin) x (connect, substribe)
+                1,  # child2 peer active
+            ]
+        )
+        await await_for(
+            lambda: child2.links.num_pending == 0
+            and child1.links.num_pending == exp_child1_events,
+            1,
+            f"ERROR waiting for child1 to receive {exp_child1_events} events",
+            err_str_f=h.summary_str,
+        )
+        assert child1.links.num_pending == exp_child1_events
+        assert child1.links.num_in_flight == 0
+        assert child1.event_persister.num_persists == exp_child1_events
+        assert child1.event_persister.num_retrieves == 0
+        assert child1.event_persister.num_clears == 0
+        assert child2.links.num_pending == 0
+        assert child2.links.num_in_flight == 0
+        # child2 never persists its own peer active, and whether it persists
+        # admin events depends on when child1 link goes active
+        assert 3 <= child2.event_persister.num_persists <= 5
+        assert child2.event_persister.num_persists == 5
+        assert (
+            child2.event_persister.num_retrieves == child2.event_persister.num_persists
+        )
+        assert child2.event_persister.num_clears == child2.event_persister.num_persists
+
 
 @pytest.mark.asyncio
 async def test_tree_parent_comm(request: Any) -> None:
@@ -148,6 +215,63 @@ async def test_tree_parent_comm(request: Any) -> None:
             "link1toAtn.active() and linkAtnto1.active()",
             err_str_f=h.summary_str,
         )
+
+        # wait for all events to be at rest
+        exp_child2_events = sum(
+            [
+                1,  # child2 startup
+                4,  # child2 (child1, admin) x (connect, substribe)
+                1,  # child2 peer active
+            ]
+        )
+        exp_child1_events = sum(
+            [
+                1,  # child1 startup
+                6,  # child1 (parent, child2, admin) x (connect, subscribe)
+                2,  # child1 (parent, child2) x peer active
+                exp_child2_events,
+            ]
+        )
+        exp_parent_events = sum(
+            [
+                1,  # parent startup
+                2,  # parent connect, subscribe
+                1,  # child1 peer active
+                exp_child1_events,
+            ]
+        )
+        await await_for(
+            lambda: h.child1.links.num_pending == 0
+            and h.child2.links.num_pending == 0
+            and h.parent.links.num_pending == exp_parent_events,
+            1,
+            f"ERROR waiting for parent to persist {exp_parent_events} events",
+            err_str_f=h.summary_str,
+        )
+        persister0 = h.parent.event_persister
+        persister1 = h.child1.event_persister
+        persister2 = h.child2.event_persister
+        assert h.parent.links.num_pending == exp_parent_events
+        assert h.parent.links.num_in_flight == 0
+        assert persister0.num_persists == exp_parent_events
+        assert persister0.num_retrieves == 0
+        assert persister0.num_clears == 0
+        assert h.child1.links.num_pending == 0
+        assert h.child1.links.num_in_flight == 0
+        # child 1 will persist between 3 and (exp_child1_events - 1) events, depending
+        # on when parent link went active
+        assert 3 <= persister1.num_persists <= (exp_child1_events - 1), h.summary_str()
+        assert persister1.num_retrieves == persister1.num_persists
+        assert persister1.num_clears == persister1.num_persists
+
+        assert h.child2.links.num_pending == 0
+        assert h.child2.links.num_in_flight == 0
+        # child2 never persists its own peer active, and whether it persists
+        # admin events depends on when child1 link goes active
+        assert 3 <= persister2.num_persists <= 5
+        assert persister2.num_persists == 5
+        assert persister2.num_retrieves == persister2.num_persists
+        assert persister2.num_clears == persister2.num_persists
 
 
 @pytest.mark.asyncio
@@ -194,3 +318,65 @@ async def test_tree_event_forward(request: Any) -> None:
             "ERROR waiting for atn to hear reports",
             err_str_f=h.summary_str,
         )
+
+        # wait for all events to be at rest
+        exp_child2_events = sum(
+            [
+                1,  # child2 startup
+                4,  # child2 (child1, admin) x (connect, substribe)
+                1,  # child2 peer active
+                2,  # relay set, relay report
+            ]
+        )
+        exp_child1_events = sum(
+            [
+                1,  # child1 startup
+                6,  # child1 (parent, child2, admin) x (connect, subscribe)
+                2,  # child1 (parent, child2) x peer active
+                exp_child2_events,
+            ]
+        )
+        exp_parent_events = sum(
+            [
+                1,  # parent startup
+                2,  # parent connect, subscribe
+                1,  # child1 peer active
+                exp_child1_events,
+            ]
+        )
+        await await_for(
+            lambda: h.child1.links.num_pending == 0
+            and h.child2.links.num_pending == 0
+            and h.parent.links.num_pending == exp_parent_events,
+            1,
+            f"ERROR waiting for parent to persist {exp_parent_events} events",
+            err_str_f=h.summary_str,
+        )
+        persister0 = h.parent.event_persister
+        persister1 = h.child1.event_persister
+        persister2 = h.child2.event_persister
+        assert h.parent.links.num_pending == exp_parent_events
+        assert h.parent.links.num_in_flight == 0
+        assert persister0.num_persists == exp_parent_events
+        assert persister0.num_retrieves == 0
+        assert persister0.num_clears == 0
+        assert h.child1.links.num_pending == 0
+        if h.child1.links.num_in_flight != 0:
+            import rich
+
+            rich.print(h.child1.links.in_flight_events)
+        assert h.child1.links.num_in_flight == 0
+        # child 1 will persist between 3 and (exp_child1_events - 1) events, depending
+        # on when parent link went active
+        assert 3 <= persister1.num_persists <= (exp_child1_events - 1), h.summary_str()
+        assert persister1.num_retrieves == persister1.num_persists
+        assert persister1.num_clears == persister1.num_persists
+
+        assert h.child2.links.num_pending == 0
+        assert h.child2.links.num_in_flight == 0
+        # child2 never persists its own peer active, and whether it persists
+        # admin events depends on when child1 link goes active
+        assert 3 <= persister2.num_persists <= 5
+        assert persister2.num_persists == 5
+        assert persister2.num_retrieves == persister2.num_persists
+        assert persister2.num_clears == persister2.num_persists


### PR DESCRIPTION
When the link is active, new events are no longer persisted, but instead kept in an in-flight buffer. If the buffer fills up, new events are persisted until the buffer has more room. This saves write, read and clear processing time and flash usage for most events.